### PR TITLE
feat: import all stories from implementation repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Automated workflows watch the main repository for:
 3. Initialize story agent prompts
 4. Establish workflow with implementation repo
 
+Import branch
+--------------
+
+When migrating stories from the implementation repo, use the `feature/import-stories-from-impl` branch. Place incoming stories into `backlog/` and open a PR for the planning agent to review and assign.
+
 ## Usage
 
 ### For Planning Agent

--- a/backlog/stories/impl/ADVANCED_NFL_STATISTICS_INTEGRATION.md
+++ b/backlog/stories/impl/ADVANCED_NFL_STATISTICS_INTEGRATION.md
@@ -1,0 +1,63 @@
+---
+id: ADVANCED_NFL_STATISTICS_INTEGRATION
+epic: analytics
+status: draft
+owner: TBD
+priority: medium
+estimate: null
+dependencies: []
+tags: [advanced-stats]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Gold
+  input_path: null
+  notes: null
+---
+
+# User Story: Advanced NFL Statistics Integration
+
+## Overview
+**As a** data scientist  
+**I want** advanced NFL statistics integrated into our prediction system  
+**So that** I can build more accurate models based on detailed performance metrics
+
+## Value Proposition
+Advanced statistics provide deeper insights into team and player performance beyond basic box scores. Integrating metrics like EPA, DVOA, and Next Gen Stats creates predictive advantages and more nuanced betting recommendations.
+
+## Acceptance Criteria
+- System collects advanced statistics from specialized sources
+- Data includes team and player efficiency metrics, advanced situational stats, and play-by-play data
+- Historical data is available for model training and backtesting
+- Data is processed into a standardized format for feature engineering
+- ML models can incorporate advanced metrics as features
+- UI can display relevant advanced statistics for context
+- LLM can reference advanced statistics in betting narratives
+
+## Technical Requirements
+- Implement data collection from specialized NFL stats providers
+- Create schema for advanced statistics storage
+- Develop feature engineering for advanced metrics
+- Integrate advanced stats into ML pipelines
+- Expose relevant metrics to UI and LLM components
+
+## Implementation Plan
+1. Research and select optimal advanced statistics sources
+2. Implement data collection and storage
+3. Create feature engineering for advanced metrics
+4. Integrate with prediction models
+5. Update UI to display relevant advanced stats
+6. Enhance LLM prompts to include advanced statistical context
+
+## Definition of Done
+- Advanced statistics are collected, processed, and available in the feature store
+- ML models can access advanced features for predictions
+- UI displays relevant advanced statistics for context
+- LLM generates narratives that reference key advanced metrics
+
+## Related Features
+- Data Source Integration Framework (dependency)
+- Feature Engineering (will be enhanced)
+- Model Training & Evaluation (will be enhanced)

--- a/backlog/stories/impl/AI_GENERATED_SALES_PITCH.md
+++ b/backlog/stories/impl/AI_GENERATED_SALES_PITCH.md
@@ -1,0 +1,57 @@
+---
+id: AI_GENERATED_SALES_PITCH
+epic: ui_explainability
+status: draft
+owner: TBD
+priority: medium
+estimate: null
+dependencies: []
+tags: [explainability, ui]
+market: null
+layer: Predictions
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Predictions
+  input_path: null
+  notes: null
+---
+
+# User Story: AI-Generated Sales Pitch
+
+## Overview
+**As a** sports bettor  
+**I want** natural language explanations for betting recommendations  
+**So that** I can understand the reasoning behind predictions and make more informed decisions
+
+## Value Proposition
+Translates numerical predictions into persuasive reasoning that bettors can understand and trust. This increases user engagement and confidence in the system's recommendations.
+
+## Acceptance Criteria
+- System generates coherent narrative explanations for each game prediction
+- Explanations incorporate relevant factors (injuries, odds movement, efficiency metrics)
+- Content is persuasive and tailored to the specific betting market (moneyline, spread, over/under)
+- Generated text is free of factual errors or contradictions
+
+## Technical Requirements
+- Implement LLM integration to convert prediction data into narrative text
+- Create templates for different betting markets
+- Develop a system to track which factors influenced each prediction
+- Ensure generated content meets quality standards
+
+## Implementation Plan
+1. Design prompt templates for each market type
+2. Implement API integration with a suitable LLM provider
+3. Create a pipeline to convert prediction data into structured input for the LLM
+4. Develop quality assurance checks for the generated content
+5. Integrate with the existing prediction workflow
+
+## Definition of Done
+- For each game prediction, a coherent "pitch" is generated that explains the reasoning
+- Pitches are specific to the game and betting market context
+- System can handle all NFL games in a given week
+- Content meets readability and quality standards
+
+## Related Features
+- Prediction Generation (dependency)
+- Web Interface Display (will consume this feature)

--- a/backlog/stories/impl/BACKTESTING_ROI_TRACKING.md
+++ b/backlog/stories/impl/BACKTESTING_ROI_TRACKING.md
@@ -1,0 +1,59 @@
+---
+id: BACKTESTING_ROI_TRACKING
+epic: backtesting
+status: draft
+owner: TBD
+priority: high
+estimate: null
+dependencies: []
+tags: [backtesting, roi]
+market: null
+layer: Analysis
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Analysis
+  input_path: null
+  notes: null
+---
+
+# User Story: Backtesting & ROI Tracking
+
+## Overview
+**As a** model developer  
+**I want** to backtest models against historical data with ROI metrics  
+**So that** I can validate model performance in financial terms before deploying
+
+## Value Proposition
+Validates whether the prediction models would have actually made money in real-world betting scenarios. This provides a more relevant performance metric than simple accuracy and helps optimize betting strategies.
+
+## Acceptance Criteria
+- System can run simulated bets against historical seasons
+- Performance metrics include ROI, variance, and maximum drawdown
+- Multiple betting strategies can be tested (e.g., flat bets, Kelly criterion)
+- Results can be filtered by market type, season, team, and other factors
+
+## Technical Requirements
+- Create a `busta backtest <range>` command for the CLI
+- Implement betting simulation algorithms for different strategies
+- Develop ROI calculation and performance metrics
+- Create visualization capabilities for performance analysis
+
+## Implementation Plan
+1. Design a backtest module architecture
+2. Implement historical data loading and preparation
+3. Create betting strategy simulators
+4. Develop performance metrics calculations
+5. Build reporting and visualization components
+6. Integrate with the CLI and existing infrastructure
+
+## Definition of Done
+- Backtests align with known historical outcomes
+- System can compare multiple strategies on the same dataset
+- Performance metrics are accurate and comprehensive
+- Results provide actionable insights for model tuning
+
+## Related Features
+- Performance Tracking System (enhancement)
+- Model Training (dependency)
+- Dashboard Generation (will consume this feature)

--- a/backlog/stories/impl/DATA_SOURCE_INTEGRATION_FRAMEWORK.md
+++ b/backlog/stories/impl/DATA_SOURCE_INTEGRATION_FRAMEWORK.md
@@ -1,0 +1,60 @@
+---
+id: DATA_SOURCE_INTEGRATION_FRAMEWORK
+epic: infra
+status: draft
+owner: TBD
+priority: medium
+estimate: null
+dependencies: []
+tags: [ingestion, integration]
+market: null
+layer: Raw
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Raw
+  input_path: null
+  notes: null
+---
+
+# User Story: Data Source Integration Framework
+
+## Overview
+**As a** data engineer  
+**I want** a standardized framework for integrating new data sources  
+**So that** we can consistently add new predictive signals with minimal effort
+
+## Value Proposition
+Enables rapid integration of new data sources to enhance prediction accuracy and add unique insights. A standardized framework reduces development time and ensures consistent data handling across all sources.
+
+## Acceptance Criteria
+- New data sources can be added without modifying core pipeline code
+- Standard interfaces exist for data collection, validation, and transformation
+- Integration points are defined for machine learning, LLM training, and UI access
+- Data quality checks are automatically applied to new sources
+- Documentation template exists for new data sources
+
+## Technical Requirements
+- Create abstract base classes/interfaces for data source integration
+- Implement standardized data validation and schema enforcement
+- Define standard metadata requirements for new sources
+- Develop automated testing framework for data sources
+- Create configuration templates for new source definitions
+
+## Implementation Plan
+1. Design abstract interfaces for data source classes
+2. Create data quality validation framework
+3. Implement metadata generation for new sources
+4. Develop documentation templates for source integration
+5. Build integration tests for the framework
+
+## Definition of Done
+- Framework allows adding new sources without modifying core code
+- New sources automatically integrate with ML pipelines, LLMs, and UI
+- Documentation exists for implementing new data sources
+- Integration tests validate the framework's functionality
+
+## Related Features
+- Data Pipeline Infrastructure (dependency)
+- Feature Engineering (will consume this feature)
+- Model Training (will consume this feature)

--- a/backlog/stories/impl/GOLD_FEATURE_STORE.md
+++ b/backlog/stories/impl/GOLD_FEATURE_STORE.md
@@ -1,0 +1,57 @@
+---
+id: GOLD_FEATURE_STORE
+epic: feature_store
+status: draft
+owner: TBD
+priority: high
+estimate: null
+dependencies: []
+tags: [feature-store, schema]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Gold
+  input_path: null
+  notes: null
+---
+
+# User Story: Gold Feature Store
+
+## Overview
+**As a** data scientist  
+**I want** a canonical feature store with consistent schemas  
+**So that** model training is reproducible and features are standardized
+
+## Value Proposition
+Provides a single "truth layer" of features that prevents drift and ensures reproducibility across model iterations. This enables consistent model training and evaluation while making feature engineering transparent.
+
+## Acceptance Criteria
+- All features follow defined schemas with appropriate data types
+- ETL processes populate gold datasets from raw/bronze/silver data
+- All model inputs come exclusively from the gold feature store
+- Feature versioning allows tracking changes over time
+
+## Technical Requirements
+- Define schemas for all feature types (team stats, game stats, odds, etc.)
+- Implement ETL processes to transform and validate data
+- Store gold features in `data/gold/` with appropriate organization
+- Create documentation for available features
+
+## Implementation Plan
+1. Define feature schemas and documentation standards
+2. Implement ETL pipelines for core feature sets
+3. Develop validation checks for data quality
+4. Create feature catalog for discoverability
+5. Implement versioning strategy
+
+## Definition of Done
+- All models use features exclusively from the gold feature store
+- Features meet quality and completeness standards
+- Documentation exists for all available features
+- ETL processes run reliably and maintain data integrity
+
+## Related Features
+- Data Sources Implementation (dependency)
+- Data Layer Architecture (related)

--- a/backlog/stories/impl/KAGGLE_DATA_UTILIZATION.md
+++ b/backlog/stories/impl/KAGGLE_DATA_UTILIZATION.md
@@ -1,0 +1,65 @@
+---
+id: KAGGLE_DATA_UTILIZATION
+epic: data_sources
+status: draft
+owner: TBD
+priority: low
+estimate: null
+dependencies: []
+tags: [external-data]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: kaggle
+  layer: Bronze
+  input_path: null
+  notes: null
+---
+
+# User Story: Kaggle Data Utilization
+
+## Overview
+**As a** data scientist  
+**I want** to fully leverage our existing Kaggle NFL datasets  
+**So that** I can extract additional predictive signals and historical context for our models
+
+## Value Proposition
+We have a substantial collection of untapped Kaggle data including game scores, play-by-play data, player statistics, team statistics, betting data, and more. Properly integrating this data into our feature engineering process will enhance model accuracy and provide richer historical context for predictions.
+
+## Acceptance Criteria
+- All relevant Kaggle datasets are analyzed and cataloged with their potential value
+- Data is transformed from raw format to normalized bronze/silver layers
+- Feature engineering pipelines extract valuable signals from Kaggle data
+- Historical play-by-play data is utilized for advanced metrics
+- Betting history data is incorporated into backtesting
+- ML models can access features derived from Kaggle datasets
+- UI and LLM components can reference insights from Kaggle data
+
+## Technical Requirements
+- Create data processing scripts for each valuable Kaggle dataset
+- Implement bronze/silver transformation pipelines
+- Develop feature engineering algorithms for each dataset type
+- Integrate with existing ML pipelines
+- Update UI and LLM components to access new data
+
+## Implementation Plan
+1. Complete inventory of available Kaggle datasets
+2. Assess data quality and potential value of each dataset
+3. Prioritize datasets based on potential impact
+4. Implement data processing for high-priority datasets
+5. Create feature engineering for high-value signals
+6. Integrate with ML models
+7. Update UI and LLM to access new insights
+
+## Definition of Done
+- High-value Kaggle datasets are fully processed in bronze/silver layers
+- Feature engineering extracts valuable signals from these datasets
+- ML models incorporate features from Kaggle data
+- UI and LLM can reference insights derived from Kaggle data
+- Documentation exists for all Kaggle data transformations
+
+## Related Features
+- Data Source Integration Framework (dependency)
+- Gold Feature Store (will be enhanced)
+- Backtesting & ROI Tracking (will be enhanced)

--- a/backlog/stories/impl/MODEL_TRAINING_EVALUATION.md
+++ b/backlog/stories/impl/MODEL_TRAINING_EVALUATION.md
@@ -1,0 +1,59 @@
+---
+id: MODEL_TRAINING_EVALUATION
+epic: modeling
+status: draft
+owner: TBD
+priority: high
+estimate: null
+dependencies: []
+tags: [modeling, evaluation]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Gold
+  input_path: null
+  notes: null
+---
+
+# User Story: Model Training & Evaluation
+
+## Overview
+**As a** betting analyst  
+**I want** trained machine learning models with transparent metrics  
+**So that** I can make accurate predictions with measurable confidence
+
+## Value Proposition
+Provides predictive power for betting decisions across different markets (moneyline, against the spread, over/under). Transparent evaluation metrics build trust and allow continuous improvement.
+
+## Acceptance Criteria
+- Models can be trained for different betting markets
+- Training process is reproducible and configurable
+- Performance metrics include accuracy, AUC, and betting ROI
+- Models are stored with metadata for version tracking
+- Evaluation results are clearly documented
+
+## Technical Requirements
+- Implement `busta train <market>` command for model training
+- Create training pipelines that use gold features
+- Develop evaluation framework with multiple metrics
+- Implement model storage and versioning
+- Create documentation for model performance
+
+## Implementation Plan
+1. Design model architecture for each market type
+2. Implement training pipelines with appropriate algorithms
+3. Develop comprehensive evaluation framework
+4. Create model storage and versioning system
+5. Build reporting components for model performance
+
+## Definition of Done
+- Models can be trained with `busta train` command
+- Metrics show performance better than baseline strategies
+- Models are stored with appropriate metadata
+- Documentation exists for model approaches and performance
+
+## Related Features
+- Gold Feature Store (dependency)
+- Predictions & Outputs (will use this feature)

--- a/backlog/stories/impl/NFL_PLAYER_INJURY_DATA_INTEGRATION.md
+++ b/backlog/stories/impl/NFL_PLAYER_INJURY_DATA_INTEGRATION.md
@@ -1,0 +1,62 @@
+---
+id: NFL_PLAYER_INJURY_DATA_INTEGRATION
+epic: ingestion
+status: draft
+owner: TBD
+priority: high
+estimate: null
+dependencies: []
+tags: [injury, data]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: injury_provider
+  layer: Bronze
+  input_path: null
+  notes: null
+---
+
+# User Story: NFL Player Injury Data Integration
+
+## Overview
+**As a** betting analyst  
+**I want** comprehensive player injury data integrated into our system  
+**So that** I can assess the impact of injuries on game outcomes and betting lines
+
+## Value Proposition
+Injuries significantly impact game outcomes and betting lines. Integrating detailed player injury data allows for more accurate predictions and provides critical context for betting decisions.
+
+## Acceptance Criteria
+- System collects injury data from reliable sources (official NFL injury reports, third-party APIs)
+- Data includes injury type, severity, player position, and expected return timeline
+- Information is standardized and integrated into machine learning features
+- Historical injury data is available for backtesting
+- UI shows relevant injury information for upcoming games
+- LLM can reference injury data when generating betting narratives
+
+## Technical Requirements
+- Implement data collection from injury report sources
+- Create schema for injury data storage
+- Develop feature engineering for injury impact (team strength adjustments)
+- Integrate injury data into ML pipelines
+- Expose injury data to UI and LLM components
+
+## Implementation Plan
+1. Research and select optimal injury data sources
+2. Implement data collection and storage
+3. Create feature engineering for injury impact
+4. Integrate with prediction models
+5. Update UI to display injury information
+6. Enhance LLM prompts to include injury context
+
+## Definition of Done
+- Injury data is collected, processed, and available in the feature store
+- ML models can access injury features for predictions
+- UI displays relevant injury information for games
+- LLM generates narratives that reference key injuries
+
+## Related Features
+- Data Source Integration Framework (dependency)
+- Feature Engineering (will be enhanced)
+- Predictions & Outputs (will be enhanced)

--- a/backlog/stories/impl/PREDICTIONS_OUTPUTS.md
+++ b/backlog/stories/impl/PREDICTIONS_OUTPUTS.md
@@ -1,0 +1,58 @@
+---
+id: PREDICTIONS_OUTPUTS
+epic: predictions
+status: draft
+owner: TBD
+priority: high
+estimate: null
+dependencies: []
+tags: [outputs, infra]
+market: null
+layer: Predictions
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: Predictions
+  input_path: null
+  notes: null
+---
+
+# User Story: Predictions & Outputs
+
+## Overview
+**As a** sports bettor  
+**I want** clear predictions for upcoming games  
+**So that** I can make informed betting decisions
+
+## Value Proposition
+Translates model outputs into actionable predictions that drive the end-user experience. This is the core value delivery of the system that enables users to place informed bets.
+
+## Acceptance Criteria
+- System generates predictions for all games in the current week
+- Predictions include confidence scores and supporting metrics
+- Outputs are formatted consistently and stored in a structured way
+- Predictions are available for different betting markets
+
+## Technical Requirements
+- Implement `busta predict <week>` command
+- Create prediction pipeline that uses trained models
+- Develop output format with all necessary information
+- Store predictions in `data/predictions/` with appropriate organization
+
+## Implementation Plan
+1. Design prediction process workflow
+2. Implement prediction generation for each market type
+3. Create consistent output format with confidence scores
+4. Develop storage strategy for predictions
+5. Build integration with downstream systems (UI, reporting)
+
+## Definition of Done
+- Predictions generate for all games with confidence scores
+- Outputs include all necessary context for decision-making
+- Prediction files are consistently formatted and organized
+- Command works reliably for all supported betting markets
+
+## Related Features
+- Model Training & Evaluation (dependency)
+- Performance Tracking (will use this feature)
+- Web Interface (will consume this feature)

--- a/backlog/stories/impl/PUBLIC_BETTING_DATA_INTEGRATION.md
+++ b/backlog/stories/impl/PUBLIC_BETTING_DATA_INTEGRATION.md
@@ -1,0 +1,61 @@
+---
+id: PUBLIC_BETTING_DATA_INTEGRATION
+epic: ingestion
+status: draft
+owner: TBD
+priority: medium
+estimate: null
+dependencies: []
+tags: [betting, trends]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: public_betting
+  layer: Bronze
+  input_path: null
+  notes: null
+---
+
+# User Story: Public Betting Data Integration
+
+## Overview
+**As a** betting analyst  
+**I want** public betting data integrated into our prediction system  
+**So that** I can identify value opportunities where our predictions differ from public sentiment
+
+## Value Proposition
+Understanding public betting patterns enables contrarian strategies and reveals market inefficiencies. Integrating public betting percentages and line movement data helps identify value bets where public sentiment may be driving non-optimal lines.
+
+## Acceptance Criteria
+- System collects public betting percentages, money distribution, and line movement data
+- Data is collected from multiple sportsbooks for comprehensive coverage
+- Historical data is available for analysis of public betting patterns
+- Data is processed into a standardized format for feature engineering
+- UI displays public betting information alongside predictions
+- LLM can reference public betting trends in generating narratives
+
+## Technical Requirements
+- Implement data collection from public betting data sources
+- Create schema for betting trend data storage
+- Develop line movement analysis capabilities
+- Integrate public betting data into UI visualizations
+- Expose public betting context to LLM components
+
+## Implementation Plan
+1. Research and select reliable public betting data sources
+2. Implement data collection and storage
+3. Create analysis tools for line movement and betting trends
+4. Integrate with UI for visualization
+5. Enhance LLM prompts to include public betting context
+
+## Definition of Done
+- Public betting data is collected, processed, and available in the system
+- UI displays public betting percentages and line movement
+- Value bet identification considers divergence from public sentiment
+- LLM generates narratives that reference relevant public betting trends
+
+## Related Features
+- Data Source Integration Framework (dependency)
+- UI Visualization Components (will be enhanced)
+- AI-Generated Sales Pitch (will be enhanced)

--- a/backlog/stories/impl/README.md
+++ b/backlog/stories/impl/README.md
@@ -1,0 +1,43 @@
+# User Stories
+
+This directory contains user stories for features that are planned or in development for the NFL Predictions system.
+
+## Story Format
+
+Each story follows a standardized format:
+
+- **Overview**: User story in the format "As a [role], I want [feature] so that [benefit]"
+- **Value Proposition**: Explanation of the business/user value
+- **Acceptance Criteria**: Specific, testable requirements
+- **Technical Requirements**: Implementation details
+- **Implementation Plan**: Outline of implementation steps
+- **Definition of Done**: Criteria for considering the story complete
+- **Related Features**: Dependencies and relationships to other features
+
+## Current Stories
+
+- [Advanced NFL Statistics Integration](./ADVANCED_NFL_STATISTICS_INTEGRATION.md) - Integration of advanced NFL stats for better predictions
+- [AI-Generated Sales Pitch](./AI_GENERATED_SALES_PITCH.md) - Natural language explanations for betting recommendations
+- [Backtesting & ROI Tracking](./BACKTESTING_ROI_TRACKING.md) - Historical backtests with ROI metrics
+- [Data Source Integration Framework](./DATA_SOURCE_INTEGRATION_FRAMEWORK.md) - Framework for adding new data sources
+- [Gold Feature Store](./GOLD_FEATURE_STORE.md) - Canonical feature store with consistent schemas
+- [Kaggle Data Utilization](./KAGGLE_DATA_UTILIZATION.md) - Utilizing existing Kaggle datasets for enhanced predictions
+- [Model Training & Evaluation](./MODEL_TRAINING_EVALUATION.md) - ML model training with transparent metrics
+- [NFL Player Injury Data Integration](./NFL_PLAYER_INJURY_DATA_INTEGRATION.md) - Integration of player injury data
+- [Predictions & Outputs](./PREDICTIONS_OUTPUTS.md) - Model inference for betting decisions
+- [Public Betting Data Integration](./PUBLIC_BETTING_DATA_INTEGRATION.md) - Integration of public betting trends data
+- [Scheduling & Automation](./SCHEDULING_AUTOMATION.md) - Automated data collection on schedules
+- [Weather Data Integration](./WEATHER_DATA_INTEGRATION.md) - Integration of weather data for game predictions
+
+### LLM-Enhanced Stories
+
+- [News RSS Sources Integration](./NEWS_RSS_SOURCES_INTEGRATION.md) - Curated NFL news RSS sources for LLM processing
+- [LLM Feature Extraction from News](./LLM_FEATURE_EXTRACTION_FROM_NEWS.md) - Convert articles into structured game signals
+
+### Completed Stories
+
+- [Configuration Standards (YAML + Pydantic)](../completed/CONFIG_STANDARDS_YAML_PYDANTIC.md) - ✅ Standardized config patterns for LLM pipeline
+
+## Adding New Stories
+
+When creating a new user story, please follow the template format and file naming convention (UPPERCASE_WITH_UNDERSCORES.md).

--- a/backlog/stories/impl/SCHEDULING_AUTOMATION.md
+++ b/backlog/stories/impl/SCHEDULING_AUTOMATION.md
@@ -1,0 +1,57 @@
+---
+id: SCHEDULING_AUTOMATION
+epic: infra
+status: draft
+owner: TBD
+priority: medium
+estimate: null
+dependencies: []
+tags: [scheduling, automation]
+market: null
+layer: Raw
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: scheduler
+  layer: Raw
+  input_path: null
+  notes: null
+---
+
+# User Story: Scheduling & Automation
+
+## Overview
+**As a** data engineer  
+**I want** automated, scheduled data collection  
+**So that** the system consistently has fresh data without manual intervention
+
+## Value Proposition
+Ensures data reliability and freshness by automating collection at appropriate intervals. This reduces manual effort, prevents data gaps, and maintains consistent data quality for downstream processes.
+
+## Acceptance Criteria
+- System automatically collects data from all sources on appropriate schedules
+- Collection jobs are logged with success/failure status
+- Failed jobs trigger notifications
+- Log rotation prevents excessive disk usage
+
+## Technical Requirements
+- Implement cron jobs or scheduling system to run `busta collect` commands
+- Create a logging system that captures run details
+- Implement log rotation and archiving
+- Develop failure notification system
+
+## Implementation Plan
+1. Define appropriate collection schedules for each data source
+2. Implement scheduling mechanism (cron jobs or scheduler)
+3. Create logging infrastructure with rotation
+4. Develop monitoring and notification system
+5. Test automated collection over multiple cycles
+
+## Definition of Done
+- Scheduled pulls successfully execute for all data sources
+- Logs capture collection details and rotate appropriately
+- System detects and notifies on collection failures
+- No manual intervention required for normal operation
+
+## Related Features
+- Data Sources Implementation (dependency)
+- Unified CLI (dependency)

--- a/backlog/stories/impl/WEATHER_DATA_INTEGRATION.md
+++ b/backlog/stories/impl/WEATHER_DATA_INTEGRATION.md
@@ -1,0 +1,64 @@
+---
+id: WEATHER_DATA_INTEGRATION
+epic: ingestion
+status: draft
+owner: TBD
+priority: low
+estimate: null
+dependencies: []
+tags: [weather, external-data]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: weather_api
+  layer: Bronze
+  input_path: null
+  notes: null
+---
+
+# User Story: Weather Data Integration
+
+## Overview
+**As a** betting analyst  
+**I want** historical and forecast weather data integrated into predictions  
+**So that** I can assess weather impacts on game totals and team performance
+
+## Value Proposition
+Weather conditions significantly impact scoring and team performance, particularly for outdoor stadiums. Integrating weather data provides critical context for over/under bets and team-specific predictions in adverse conditions.
+
+## Acceptance Criteria
+- System collects historical and forecast weather data for game locations
+- Data includes temperature, precipitation, wind speed/direction, and other relevant metrics
+- Weather data is associated with specific games and venues
+- Machine learning features incorporate weather conditions
+- UI displays weather information for upcoming games
+- LLM can reference weather conditions in betting narratives
+
+## Technical Requirements
+- Implement data collection from weather APIs/services
+- Create schema for weather data storage
+- Develop feature engineering for weather impact
+- Integrate weather data into ML pipelines
+- Expose weather data to UI and LLM components
+
+## Implementation Plan
+1. Research and select optimal weather data sources
+2. Implement data collection and storage
+3. Create venue database with dome/outdoor classification
+4. Develop feature engineering for weather impact
+5. Integrate with prediction models
+6. Update UI to display weather information
+7. Enhance LLM prompts to include weather context
+
+## Definition of Done
+- Weather data is collected, processed, and available in the feature store
+- ML models can access weather features for predictions
+- UI displays relevant weather information for games
+- LLM generates narratives that reference significant weather factors
+
+## Related Features
+- Data Source Integration Framework (dependency)
+- Venue Database (dependency)
+- Feature Engineering (will be enhanced)
+- Predictions & Outputs (will be enhanced)

--- a/backlog/stories/impl/_template.md
+++ b/backlog/stories/impl/_template.md
@@ -1,0 +1,58 @@
+---
+# Story template for docs/stories
+id: STORY-ID
+epic: epic-name
+status: draft # draft | in-progress | blocked | done
+owner: team-or-person
+priority: medium # low | medium | high
+estimate: null # e.g. 2d, 3sp, or null
+dependencies: []
+tags: []
+market: null # moneyline | ats | ou | null
+layer: null # Raw | Bronze | Silver | Gold | Predictions | Results | Analysis | Reports | Dashboard
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: null
+  layer: null
+  input_path: null
+  notes: null
+---
+
+# Title: Short descriptive title
+
+Summary
+- One-paragraph summary of the story and goal.
+
+Acceptance criteria
+- Clear, testable bullets that define done.
+
+Done checklist
+- [ ] Implementation completed
+- [ ] Tests/validation added
+- [ ] Documentation updated
+
+How to run / validate (CLI-first)
+Use `busta` commands where applicable. Provide minimal example commands.
+
+```bash
+# Example: run feature generation for moneyline
+busta features --market moneyline
+
+# Example: run pipeline step
+busta pipeline data normalize-bronze
+```
+
+Design / Implementation notes
+- Short notes about approach, data shapes, edge cases.
+
+Machine-readable fields (for automation)
+- `emit_metadata` block above should be filled for sources and inputs.
+
+Related issues / PRs
+- Link to relevant issue or PR
+
+Recommended reviewer(s)
+- @handle or team name
+
+Edge cases
+- Enumerate 2-4 likely edge cases (missing data, rate limits, name collisions)

--- a/backlog/stories/impl/llm_backlog/README.md
+++ b/backlog/stories/impl/llm_backlog/README.md
@@ -1,0 +1,35 @@
+# LLM Backlog — Epic README
+
+Purpose
+- Short summary: coordinate LLM-related stories (ingest, features, infra, evaluation, UI) and provide common commands and milestones.
+
+Goals
+- Produce reliable, auditable LLM signals for model inputs.
+- Provide evidence-citation and traceability for any LLM-derived features.
+- Integrate signals into the existing 9-layer pipeline (Raw → Bronze → Silver → ...).
+
+Milestones
+- M1: Ingestion & enrichment (RSS, dedup, odds API) — ING-001..ING-003
+- M2: LLM feature extraction + entity resolution — LLM-001..LLM-003
+- M3: Evaluation and modeling lift studies — EVAL-001..MOD-003
+- **M4: Social media expansion** — See `docs/stories/social_media/` (Phase 5)
+
+Common busta commands
+
+```bash
+# Run ingestion normalization
+busta pipeline data normalize-bronze
+
+# Generate features for moneyline
+busta features --market moneyline
+
+# Run a quick local evaluation harness (example)
+busta train --market moneyline
+```
+
+Where to start
+- Review `docs/stories/_template.md` and add or update stories under this folder using the front-matter.
+- Ensure each story includes `emit_metadata` when it has a data source.
+
+Automation notes
+- CI tooling will parse the YAML front-matter to surface status and owners; keep fields consistent.

--- a/backlog/stories/impl/llm_backlog/evaluation/01-offline-eval-metrics.md
+++ b/backlog/stories/impl/llm_backlog/evaluation/01-offline-eval-metrics.md
@@ -1,0 +1,45 @@
+---
+id: EVAL-001
+epic: llm_backlog
+status: draft
+owner: evaluation-team
+priority: high
+estimate: 3sp
+dependencies: []
+tags: [evaluation, metrics]
+market: null
+layer: Analysis
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: offline_eval
+  layer: Analysis
+  input_path: runs/
+  notes: Offline harness and metrics tracking
+---
+
+# EVAL-001: Offline evaluation harness & metrics tracking
+
+- **Overview**: As a quant, I want a repeatable evaluation harness so that we can compare models and track progress.
+- **Value Proposition**: Objective measurement prevents regressions.
+
+## Acceptance Criteria
+- Compute log-loss, Brier, AUC, and calibration error per market and time period.
+- Produce time-series of metrics; store under `reports/metrics_history.parquet`.
+- Simple HTML/MD report summarizing latest runs.
+
+## Technical Requirements
+- Grouped CV by season/week; robust splits.
+- Plot reliability and lift curves (matplotlib).
+- Seed handling for reproducibility.
+
+## Implementation Plan
+- Implement evaluator module.
+- Add report generator.
+- Store artifacts and wire into CI.
+
+## Definition of Done
+- Baseline metrics recorded and versioned.
+- CI fails on metric regressions beyond thresholds.
+
+## Related Features
+MOD-001, MOD-002, MOD-003

--- a/backlog/stories/impl/llm_backlog/evaluation/02-ablation-llm-lift.md
+++ b/backlog/stories/impl/llm_backlog/evaluation/02-ablation-llm-lift.md
@@ -1,0 +1,45 @@
+---
+id: EVAL-002
+epic: llm_backlog
+status: draft
+owner: evaluation-team
+priority: high
+estimate: 3sp
+dependencies: [EVAL-001]
+tags: [evaluation, ablation]
+market: null
+layer: Analysis
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: ablation_studies
+  layer: Analysis
+  input_path: runs/ablation/
+  notes: Ablation and lift measurement for LLM features
+---
+
+# EVAL-002: Ablation studies for LLM feature lift
+
+- **Overview**: As a researcher, I want ablation experiments so that we know what LLM features actually help.
+- **Value Proposition**: Prevents cost and complexity from unjustified features.
+
+## Acceptance Criteria
+- Run (Base), (Base+Market), (Base+Market+LLM minimal), (Base+Market+LLM full).
+- Report per-market lift with confidence intervals.
+- Keep features that pass a pre-agreed lift threshold and cost budget.
+
+## Technical Requirements
+- Bootstrap CIs; cost per 1k tokens tracked for each experiment.
+- Config-driven feature toggles.
+- Results written to `reports/ablation_llm.md`.
+
+## Implementation Plan
+- Add toggles and evaluator hooks.
+- Run experiments on a past season sample.
+- Summarize results and decide keep/drop list.
+
+## Definition of Done
+- Report published; keep/drop list committed.
+- Pipeline uses only kept features by default.
+
+## Related Features
+LLM-001, MOD-002

--- a/backlog/stories/impl/llm_backlog/explain/01-llm-grounded-explanations.md
+++ b/backlog/stories/impl/llm_backlog/explain/01-llm-grounded-explanations.md
@@ -1,0 +1,45 @@
+---
+id: EXP-001
+epic: llm_backlog
+status: draft
+owner: explainability-team
+priority: medium
+estimate: 2sp
+dependencies: [LLM-002]
+tags: [explainability, ui]
+market: null
+layer: Predictions
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: explanations
+  layer: Predictions
+  input_path: web_build/predictions/
+  notes: Grounded explanation cards for picks
+---
+
+# EXP-001: Grounded explanation cards for picks
+
+- **Overview**: As an end user, I want concise explanations tied to data so that I trust the recommended picks.
+- **Value Proposition**: Converts numbers into understandable narratives without hallucinations.
+
+## Acceptance Criteria
+- Explanations limited to 3 bullets + 1 risk; all claims supported by feature values or evidence quotes.
+- Strict grounding: tool may only reference fields passed in the payload, with evidence URLs whitelisted from our dataset.
+- Temperature=0; JSON schema enforced for the explanation payload.
+
+## Technical Requirements
+- Prompt template that lists allowed fields; refusal when unknown.
+- Render to UI card with links to evidence.
+- Unit tests comparing generated text vs allowed inputs.
+
+## Implementation Plan
+- Define explanation schema and prompt.
+- Implement `llm_explain.pick_card()`.
+- Wire to UI detail page and export to PDF.
+
+## Definition of Done
+- No hallucinations in 50-sample audit.
+- Average word count under 90 words; all links functional.
+
+## Related Features
+UI-002, LLM-002

--- a/backlog/stories/impl/llm_backlog/index.md
+++ b/backlog/stories/impl/llm_backlog/index.md
@@ -1,0 +1,88 @@
+---
+id: LLM-BACKLOG
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: medium
+estimate: null
+dependencies: []
+tags: [llm, backlog]
+market: null
+layer: null
+last_updated: 2025-08-24
+---
+
+# NFL Predictions — LLM-Augmented Backlog
+_Generated on 2025-08-24_
+
+This page lists the epic-level backlog for LLM-augmented features and infra. Each story should follow the repository story template at `docs/stories/_template.md` (front-matter + sections) so tooling can parse and surface metadata automatically.
+
+**Status**: 29 total stories across 7 functional areas (3 completed, 5 new stories added based on gap analysis)
+
+## Table of Contents
+- [ING-001: Expand and standardize News RSS sources](ingestion/01-news-rss-sources.md)
+- [ING-002: Article deduplication & enrichment pipeline](ingestion/02-article-dedup-enrich.md)
+- [ING-003: Odds API integration (moneyline, spread, totals, props)](ingestion/03-odds-api-integration.md)
+- [ING-004: PFR weekly schedule & team stats scraper](ingestion/04-pfr-scraper-week.md)
+- [ING-005: Content quality scoring and filtering](ingestion/05-content-quality-filtering.md)
+- [LLM-001: LLM extraction of game signals from news](llm/01-feature-extraction-from-news.md)
+- [LLM-002: Evidence citation & traceability for LLM outputs](llm/02-evidence-citation-and-traceability.md)
+- [LLM-003: Entity resolution for teams and players](llm/03-entity-resolution.md)
+- [LLM-004: Regime-change detection from weekly summaries](llm/04-regime-change-detection.md)
+- [LLM-005: Injury override & starter availability signal](llm/05-injury-override-signal.md)
+- [LLM-006: Batch processing optimization for LLM features](llm/06-batch-processing-optimization.md)
+- [MOD-001: Rebaseline ATS/ML/Total models with clean features](modeling/01-base-ats-model.md)
+- [MOD-002: Meta-model stacker with LLM-aware weighting](modeling/02-stacker-meta-model.md)
+- [MOD-003: Probability calibration & reliability curves](modeling/03-probability-calibration.md)
+- [MOD-004: Abstention and do-not-bet logic](modeling/04-abstention-logic.md)
+- [MOD-005: Feature store schema & lineage](modeling/05-feature-store-schema.md)
+- [MOD-006: Production model calibration monitoring](modeling/06-calibration-monitoring.md)
+- [EXP-001: Grounded explanation cards for picks](explain/01-llm-grounded-explanations.md)
+- [UI-001: Landing page with daily games & confidence](ui/01-landing-page-cards.md)
+- [UI-002: Game detail page with rationale and signals](ui/02-game-detail-page.md)
+- [INF-001: Configuration standards (YAML + pydantic)](infra/01-config-standards-yaml.md)
+- [INF-002: Task runner integration (busta/CLI from repo root)](infra/02-task-runner-busta.md)
+- [INF-003: Caching & TTL for time-sensitive signals](infra/03-caching-ttl.md)
+- [INF-004: Secrets management & key rotation](infra/04-secrets-management.md)
+- [INF-005: LLM provider failover and model versioning](infra/05-llm-provider-failover.md)
+- [EVAL-001: Offline evaluation harness & metrics tracking](evaluation/01-offline-eval-metrics.md)
+- [EVAL-002: Ablation studies for LLM feature lift](evaluation/02-ablation-llm-lift.md)
+- [QLT-001: Data quality checks on joins and keys](quality/01-data-quality-checks.md)
+- [QLT-002: Structured logging & lightweight monitoring](quality/02-logging-and-monitoring.md)
+- [QLT-003: Feature store monitoring and drift detection](quality/03-feature-monitoring-drift.md)
+
+## How to use this backlog
+
+- Each story under this epic should include YAML front-matter and the standard sections from `docs/stories/_template.md`.
+- Use the `busta` CLI for all runnable validation steps (see template). Examples below show common commands.
+
+## Epic-level acceptance criteria
+
+- Stories have machine-readable front-matter (id, owner, status, priority, estimate, tags, market, layer).
+- Each story includes clear acceptance criteria and a done checklist.
+- How-to-run steps use `busta` commands where applicable.
+- **Phase-based delivery**: 29 stories organized into 4 phases (Foundation → Core → Enhancement → Experience)
+- **Gap coverage**: Critical gaps identified and addressed with 5 new stories
+- **Strategic alignment**: Implementation plan documented in `docs/proposals/LLM_BACKLOG_STRATEGIC_PLAN.md`
+
+## Example busta commands (CLI-first)
+
+```bash
+# Run feature generation for moneyline (example)
+busta features --market moneyline
+
+# Run a pipeline step
+busta pipeline data normalize-bronze
+
+# Build/deploy web assets (epic-level docs or demo pages)
+busta build-web
+```
+
+## Story template
+
+Create new stories using `docs/stories/_template.md`. Stories missing required front-matter may be skipped by automation.
+
+## Related issues / PRs
+
+- (link to related issues or PRs here)
+

--- a/backlog/stories/impl/llm_backlog/infra/01-config-standards-yaml.md
+++ b/backlog/stories/impl/llm_backlog/infra/01-config-standards-yaml.md
@@ -1,0 +1,45 @@
+---
+id: INF-001
+epic: llm_backlog
+status: draft
+owner: infra-team
+priority: medium
+estimate: 2sp
+dependencies: []
+tags: [config, yaml, pydantic]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: config_standards
+  layer: Infra
+  input_path: config/
+  notes: YAML + pydantic standards
+---
+
+# INF-001: Configuration standards (YAML + pydantic)
+
+- **Overview**: As a developer, I want consistent config patterns so that new sources and models are easy to add.
+- **Value Proposition**: Consistency reduces defects and onboarding time.
+
+## Acceptance Criteria
+- All configs live under `config/` with pydantic validation.
+- Secrets are never in YAML; environment variables or .env only.
+- CLI validates config and prints helpful error messages.
+
+## Technical Requirements
+- Use `pydantic-settings`; provide `.env.example`.
+- Schema versioning for critical configs (news sources, teams).
+- Pre-commit hook to validate YAML.
+
+## Implementation Plan
+- Define pydantic models.
+- Add validators and CLI `config doctor`.
+- Document config locations and examples.
+
+## Definition of Done
+- `config doctor` passes on clean repo; fails with clear errors on bad files.
+- Docs updated; sample configs included.
+
+## Related Features
+ING-001, LLM-003

--- a/backlog/stories/impl/llm_backlog/infra/02-task-runner-busta.md
+++ b/backlog/stories/impl/llm_backlog/infra/02-task-runner-busta.md
@@ -1,0 +1,45 @@
+---
+id: INF-002
+epic: llm_backlog
+status: draft
+owner: infra-team
+priority: high
+estimate: 1sp
+dependencies: []
+tags: [cli, busta]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: busta_integration
+  layer: Infra
+  input_path: bin/busta
+  notes: CLI-first enforcement
+---
+
+# INF-002: Task runner integration (busta/CLI from repo root)
+
+- **Overview**: As a developer, I want all commands runnable from the project root so that local dev and CI are consistent.
+- **Value Proposition**: Eliminates path confusion and speeds iteration.
+
+## Acceptance Criteria
+- Single entrypoint script runs collection, training, inference, and report generation.
+- Works from repo root; relative paths handled correctly.
+- CI job executes smoke pipeline without path errors.
+
+## Technical Requirements
+- Implement `busta` or `make`-like task runner with Python entrypoint.
+- Centralize paths via `Settings` class.
+- Add integration tests that spawn subprocess from root.
+
+## Implementation Plan
+- Refactor CLI to use root-relative paths.
+- Add tasks for each pipeline stage.
+- Write CI job that runs end-to-end sample.
+
+## Definition of Done
+- `busta run sample` completes locally and in CI.
+- No hardcoded subdir assumptions remain.
+
+## Related Features
+ING-*, MOD-*, UI-*

--- a/backlog/stories/impl/llm_backlog/infra/03-caching-ttl.md
+++ b/backlog/stories/impl/llm_backlog/infra/03-caching-ttl.md
@@ -1,0 +1,45 @@
+---
+id: INF-003
+epic: llm_backlog
+status: draft
+owner: infra-team
+priority: medium
+estimate: 2sp
+dependencies: []
+tags: [caching, ttl]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: cache_policy
+  layer: Infra
+  input_path: null
+  notes: Caching and TTL for time-sensitive signals
+---
+
+# INF-003: Caching & TTL for time-sensitive signals
+
+- **Overview**: As a platform engineer, I want caching and expirations so that stale news doesn’t leak into predictions.
+- **Value Proposition**: Controls cost and correctness for LLM and news retrieval.
+
+## Acceptance Criteria
+- LLM feature cache keyed by `cluster_id` with 24h TTL (configurable).
+- News fetch cache with ETag/Last-Modified; odds cache 60s.
+- Monitoring warns when signals exceed TTL during inference.
+
+## Technical Requirements
+- Cache to disk with metadata index; purge cron/task.
+- TTL enforcement in feature loader; warnings bubble to reports.
+- Configurable via `config/runtime.yml`.
+
+## Implementation Plan
+- Implement cache layer and TTL checks.
+- Add monitoring hooks to inference.
+- Write tests for expiry and refresh behavior.
+
+## Definition of Done
+- Expired entries are refreshed automatically.
+- No inference run uses signals older than TTL.
+
+## Related Features
+LLM-001, ING-001

--- a/backlog/stories/impl/llm_backlog/infra/04-secrets-management.md
+++ b/backlog/stories/impl/llm_backlog/infra/04-secrets-management.md
@@ -1,0 +1,45 @@
+---
+id: INF-004
+epic: llm_backlog
+status: draft
+owner: infra-team
+priority: high
+estimate: 2sp
+dependencies: []
+tags: [secrets, security]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: secrets_management
+  layer: Infra
+  input_path: null
+  notes: Guidelines for key rotation
+---
+
+# INF-004: Secrets management & key rotation
+
+- **Overview**: As an admin, I want safe secret handling so that API keys and model credentials are protected.
+- **Value Proposition**: Reduces risk of key leaks and simplifies rotation.
+
+## Acceptance Criteria
+- All secret values come from env vars; `.env.example` documents names.
+- Rotation guide in `docs/secrets.md`; rotation tested in CI via injected ephemeral keys.
+- No secrets in logs or persisted prompts.
+
+## Technical Requirements
+- Use dotenv in local dev; GitHub Actions secrets in CI.
+- Redaction middleware for logs and LLM audit files.
+- Pre-commit scan for accidental secrets.
+
+## Implementation Plan
+- Implement secrets loader and redaction.
+- Add CI checks and docs.
+- Run rotation drill and document steps.
+
+## Definition of Done
+- Secret scans clean; audit logs show redacted tokens.
+- Rotation executed successfully in test.
+
+## Related Features
+ING-003, LLM-002

--- a/backlog/stories/impl/llm_backlog/infra/05-llm-provider-failover.md
+++ b/backlog/stories/impl/llm_backlog/infra/05-llm-provider-failover.md
@@ -1,0 +1,54 @@
+---
+id: INF-005
+epic: llm_backlog
+status: draft
+owner: infra-team
+priority: high
+estimate: 3sp
+dependencies: [LLM-001]
+tags: [llm, failover, versioning]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: llm_management
+  layer: Infra
+  input_path: null
+  notes: LLM provider management and fallback handling
+---
+
+# INF-005: LLM provider failover and model versioning
+
+- **Overview**: As a platform engineer, I want robust LLM provider management so that API failures don't break the pipeline and model changes are tracked.
+- **Value Proposition**: Ensures system reliability and reproducibility when LLM providers have outages or change models.
+
+## Acceptance Criteria
+- Support for multiple LLM providers (OpenAI, Anthropic, local models) with automatic failover
+- Model version tracking with ability to pin specific versions for reproducibility
+- Rate limiting and exponential backoff for API calls
+- Cost monitoring and spending alerts per provider
+- Graceful degradation when all providers fail (use cached results or abstain)
+
+## Technical Requirements
+- Provider abstraction layer with unified interface
+- Configuration-driven provider priority and fallback rules
+- API key rotation support for security
+- Comprehensive logging of provider performance and costs
+- Integration with existing caching system (INF-003)
+
+## Implementation Plan
+1. **Design provider abstraction** with unified interface for all LLM calls
+2. **Implement failover logic** with configurable retry and backoff strategies
+3. **Add model versioning** to track and pin specific model versions
+4. **Create cost monitoring** with alerts and budget limits
+5. **Add graceful degradation** when providers unavailable
+
+## Definition of Done
+- [ ] System continues functioning during provider outages
+- [ ] All LLM calls logged with provider, model version, cost, and latency
+- [ ] Cost alerts trigger before budget limits exceeded
+- [ ] Reproducible results with pinned model versions
+- [ ] <5 second failover time between providers
+
+## Related Features
+LLM-001, LLM-002, INF-003, INF-004

--- a/backlog/stories/impl/llm_backlog/ingestion/01-news-rss-sources.md
+++ b/backlog/stories/impl/llm_backlog/ingestion/01-news-rss-sources.md
@@ -1,0 +1,52 @@
+---
+id: ING-001
+epic: llm_backlog
+status: draft
+owner: team-data
+priority: high
+estimate: 2sp
+dependencies: []
+tags: [ingestion, rss]
+market: null
+layer: Raw
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: rss_feeds
+  layer: Raw
+  input_path: data/raw/news_rss/
+  notes: RSS sources list and normalization
+---
+
+# ING-001: Expand and standardize News RSS sources
+
+- **Overview**: As a data engineer, I want dozens of curated NFL news RSS sources categorized for modeling relevance so that we can systematically ingest high-signal news.
+- **Value Proposition**: More and better sources increase coverage of starter status, coach intent, and injuries that drive preseason and regular-season edges.
+
+## Acceptance Criteria
+- At least 50 unique RSS/Atom feeds configured across categories: Team beats, National outlets, Injury reports, Weather, and Fantasy/Depth Chart.
+- Config lives in a single YAML file under `config/news_sources.yml` with fields: `id`, `name`, `url`, `category`, `priority`, `team_scope` (nullable), `active` (bool).
+- Collector logs per-source fetch status, HTTP code, and item counts.
+- Duplicate items across feeds are deduped by canonical URL + title hash.
+- Daily run via CLI command `python -m src.cli collect news` populates `data/bronze/news_raw.parquet`.
+
+## Technical Requirements
+- Implement requests with conditional GET (ETag/Last-Modified).
+- Normalize to schema: `source_id, fetched_at, published_at, title, url, author, summary, content_html, content_text, team_tags`.
+- Use readability/boilerpipe-style extraction for `content_text`.
+- Add basic HTML sanitizer and strip tracking query params for canonical URL.
+
+## Implementation Plan
+- Define YAML schema and validation (pydantic).
+- Write `sources/news_rss.py` to read YAML and fetch feeds with backoff.
+- Implement HTML → text extractor with fallback.
+- Persist raw items to bronze; add dedup logic into silver layer.
+- Add unit tests with 3–5 mocked feeds.
+
+## Definition of Done
+- YAML validated in CI; sample run produces >500 items across last 48h.
+- Parquet schema documented in `docs/schemas/news_raw.md`.
+- Logs include per-source metrics and error reasons.
+- README updated with run instructions.
+
+## Related Features
+ING-002, LLM-001, LLM-003

--- a/backlog/stories/impl/llm_backlog/ingestion/02-article-dedup-enrich.md
+++ b/backlog/stories/impl/llm_backlog/ingestion/02-article-dedup-enrich.md
@@ -1,0 +1,48 @@
+---
+id: ING-002
+epic: llm_backlog
+status: draft
+owner: team-data
+priority: high
+estimate: 3sp
+dependencies: [ING-001]
+tags: [ingestion, dedup, enrichment]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: dedup_enrich
+  layer: Bronze
+  input_path: data/bronze/news/
+  notes: Deduplication, canonicalization, language detection
+---
+
+# ING-002: Article deduplication & enrichment pipeline
+
+- **Overview**: As a platform engineer, I want to deduplicate and enrich articles so that downstream LLMs receive a clean, consolidated text per story.
+- **Value Proposition**: Reduces LLM cost and noise by collapsing near-duplicates and attaching high-value metadata (teams, players).
+
+## Acceptance Criteria
+- Near-duplicate clustering based on URL canonicalization + title similarity > 0.9 or content cosine similarity > 0.92.
+- Resolved record includes `cluster_id`, chosen `canonical_url`, and merged `evidence_urls`.
+- NER tags for NFL teams and players attached to each record; team tags mapped to `game_id` when possible.
+- `data/silver/news_clean.parquet` produced with <1% duplicates on spot check.
+
+## Technical Requirements
+- Use MinHash or cosine sim over sentence embeddings for clustering.
+- Entity recognition with a sports-tuned dictionary + fuzzy match (Levenshtein/Jaro-Winkler).
+- Map team names/aliases to team codes; try to infer `game_id` using date/opponent heuristics.
+
+## Implementation Plan
+- Implement canonical URL + strip UTM parameters.
+- Build embedding pipeline and clusterer (faiss or sklearn).
+- NER + dictionary augment; persist entity spans.
+- Unit tests with synthetic near-dup sets.
+
+## Definition of Done
+- Precision/recall on duplicate test set ≥ 0.95/0.90.
+- NER spot-check accuracy > 90% on 100-sample audit.
+- Docs include rules for team/opponent/game mapping.
+
+## Related Features
+ING-001, LLM-001

--- a/backlog/stories/impl/llm_backlog/ingestion/03-odds-api-integration.md
+++ b/backlog/stories/impl/llm_backlog/ingestion/03-odds-api-integration.md
@@ -1,0 +1,47 @@
+---
+id: ING-003
+epic: llm_backlog
+status: draft
+owner: team-data
+priority: high
+estimate: 2sp
+dependencies: []
+tags: [ingestion, odds]
+market: moneyline
+layer: Raw
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: odds_api
+  layer: Raw
+  input_path: data/raw/odds/
+  notes: Moneyline/spread/total feeds
+---
+
+# ING-003: Odds API integration (moneyline, spread, totals, props)
+
+- **Overview**: As a modeler, I want market lines and implied probabilities so that our models can compare, calibrate, and generate actionable deltas.
+- **Value Proposition**: Markets encode wisdom-of-crowds priors; comparing model vs market drives bet selection and risk controls.
+
+## Acceptance Criteria
+- CLI `python -m src.cli collect odds` saves `data/bronze/odds_raw.parquet`.
+- Support for multiple books; schema includes `event_id, book, market, side, price, timestamp`.
+- Derived fields: `implied_prob`, `vig_adjusted_prob` stored in silver layer.
+- Join keys created between `event_id` and team/game dimension table.
+
+## Technical Requirements
+- Handle rate limits with backoff; cache identical requests for 60s.
+- Create `data/silver/odds.parquet` with normalized columns.
+- Support historical pulls where provider allows; otherwise snapshot current.
+
+## Implementation Plan
+- Implement provider client and auth.
+- Transform to normalized schema and write tests.
+- Add implied probability functions and vig removal per market.
+
+## Definition of Done
+- End-to-end run produces odds for all games scheduled next 7 days.
+- Unit tests for prob math and join logic pass.
+- Docs include supported books and markets.
+
+## Related Features
+MOD-002, EVAL-002

--- a/backlog/stories/impl/llm_backlog/ingestion/04-pfr-scraper-week.md
+++ b/backlog/stories/impl/llm_backlog/ingestion/04-pfr-scraper-week.md
@@ -1,0 +1,45 @@
+---
+id: ING-004
+epic: llm_backlog
+status: draft
+owner: team-data
+priority: medium
+estimate: 2sp
+dependencies: []
+tags: [ingestion, pfr]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: pfr_scraper
+  layer: Bronze
+  input_path: data/raw/pfr/
+  notes: Weekly schedule and team stats
+---
+
+# ING-004: PFR weekly schedule & team stats scraper
+
+- **Overview**: As a data scientist, I want structured schedule and recent team performance so that models can leverage form and matchup context.
+- **Value Proposition**: Provides ground truth schedule and simple rolling stats without vendor lock-in.
+
+## Acceptance Criteria
+- `python -m src.cli collect pfr-week` writes `data/bronze/pfr_week_raw.parquet`.
+- Transform step computes last-5 rolling efficiency stats for offense/defense.
+- Keys: `game_id, week, season, home_team, away_team, kickoff_et`.
+
+## Technical Requirements
+- Respect robots.txt and polite delay.
+- Cache pages to disk; parse with lxml/BeautifulSoup.
+- Unit tests for 2 sample weeks.
+
+## Implementation Plan
+- Scrape schedule and stats tables; build parsers.
+- Derive features; write to silver/gold tables.
+- Link to odds and LLM signals via `game_id`.
+
+## Definition of Done
+- Schemas documented; joins validated on 100% of upcoming games.
+- CI task scrapes a small sample during tests.
+
+## Related Features
+MOD-001, MOD-002, LLM-001

--- a/backlog/stories/impl/llm_backlog/ingestion/05-content-quality-filtering.md
+++ b/backlog/stories/impl/llm_backlog/ingestion/05-content-quality-filtering.md
@@ -1,0 +1,54 @@
+---
+id: ING-005
+epic: llm_backlog
+status: draft
+owner: team-data
+priority: medium
+estimate: 2sp
+dependencies: [ING-001, ING-002]
+tags: [ingestion, quality, filtering]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: content_quality
+  layer: Bronze
+  input_path: data/bronze/news/
+  notes: Content quality scoring before LLM processing
+---
+
+# ING-005: Content quality scoring and filtering
+
+- **Overview**: As a data engineer, I want to filter low-quality content before LLM processing so that we don't waste API costs on noise.
+- **Value Proposition**: Reduces LLM costs by 30-50% while improving signal quality by filtering spam, duplicates, and irrelevant content.
+
+## Acceptance Criteria
+- Quality scoring algorithm that considers: content length, NFL relevance, source credibility, and freshness
+- Configurable quality thresholds per content category (breaking news vs analysis)
+- Quality scores stored in `data/bronze/news_quality.parquet` with explanations
+- <5% false negative rate on manual audit of filtered content
+- Integration with LLM pipeline to skip low-quality articles
+
+## Technical Requirements
+- Lightweight ML model or heuristic scoring (no LLM required)
+- Features: NFL entity density, readability score, source ranking, publication type
+- Real-time scoring during ingestion pipeline
+- Quality distribution monitoring and alerting
+- Bypass mechanism for manual override of filtering decisions
+
+## Implementation Plan
+1. **Analyze current content quality** distribution and define quality metrics
+2. **Build quality scoring model** using content features and source metadata
+3. **Implement filtering logic** in ingestion pipeline with configurable thresholds
+4. **Add quality monitoring** dashboard and alerting for distribution shifts
+5. **Create manual override** interface for editorial review
+
+## Definition of Done
+- [ ] Quality scores correlate with manual assessment (r>0.8)
+- [ ] 30%+ reduction in articles sent to LLM without signal loss
+- [ ] Quality distribution monitoring alerts on anomalies
+- [ ] Manual audit shows <5% false negative rate
+- [ ] Integration with LLM pipeline respects quality filters
+
+## Related Features
+ING-001, ING-002, LLM-001, QLT-001

--- a/backlog/stories/impl/llm_backlog/llm/01-feature-extraction-from-news.md
+++ b/backlog/stories/impl/llm_backlog/llm/01-feature-extraction-from-news.md
@@ -1,0 +1,48 @@
+---
+id: LLM-001
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: high
+estimate: 3sp
+dependencies: [ING-001, ING-002]
+tags: [llm, features, news]
+market: null
+layer: Silver
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: news_rss
+  layer: Silver
+  input_path: data/bronze/news/
+  notes: Extracted signals will be stored in Silver layer
+---
+
+# LLM-001: LLM extraction of game signals from news
+
+- **Overview**: As a data scientist, I want LLMs to convert articles into structured game signals so that numeric models can consume high-signal context.
+- **Value Proposition**: Transforms unstructured text about starters, injuries, and coach intent into quantitative features.
+
+## Acceptance Criteria
+- Prompt outputs **JSON only** matching schema with fields: `qb_p_play`, `starter_snap_tier`, `coach_preseason_intensity`, `injury_risk_core`, `weather_penalty_pass`, `evidence` (quotes + URLs).
+- Temperature=0; responses validated against JSON schema; retry on invalid.
+- `data/gold/llm_signals.parquet` keyed by `game_id, as_of`.
+- Unknowns represented as `null` or empty arrays; no hallucinated names.
+
+## Technical Requirements
+- System prompt enforcing JSON-only + abstention.
+- pydantic schema; validator to drop/flag out-of-range values.
+- Caching by (`cluster_id`, `schema_version`).
+
+## Implementation Plan
+- Define schema and validator.
+- Implement `llm_features.extract_signals()` with batch mode.
+- Join against `news_clean` for text input; persist outputs.
+- Add unit tests on mocked articles with golden JSON.
+
+## Definition of Done
+- 100% of outputs valid JSON; <1% manual correction rate.
+- Spot-check: evidence quotes match article text exactly.
+- Feature importances show non-zero lift in ablation (see EVAL-002).
+
+## Related Features
+ING-001, ING-002, MOD-002, EVAL-002

--- a/backlog/stories/impl/llm_backlog/llm/02-evidence-citation-and-traceability.md
+++ b/backlog/stories/impl/llm_backlog/llm/02-evidence-citation-and-traceability.md
@@ -1,0 +1,45 @@
+---
+id: LLM-002
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: high
+estimate: 3sp
+dependencies: [LLM-001]
+tags: [llm, traceability, evidence]
+market: null
+layer: Silver
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: llm_outputs
+  layer: Silver
+  input_path: data/silver/llm_signals/
+  notes: Store citations and provenance metadata
+---
+
+# LLM-002: Evidence citation & traceability for LLM outputs
+
+- **Overview**: As a reviewer, I want each LLM-derived feature to include exact quotes and source URLs so that decisions are auditable.
+- **Value Proposition**: Prevents over-trust in LLMs and enables quick human audits.
+
+## Acceptance Criteria
+- Every signal includes at least one `evidence` item with exact quote and URL.
+- A `trace_id` is stored to link prompt → output → downstream model row.
+- CLI `python -m src.cli audit llm-signal --trace-id <id>` reproduces the prompt/response payloads from logs.
+
+## Technical Requirements
+- Persist prompts/responses with redacted keys in `data/logs/llm_audit/`.
+- Hash of cleaned article text + schema version as `trace_id`.
+- Audit command reads logs and prints compact JSON.
+
+## Implementation Plan
+- Add middleware to log inputs/outputs.
+- Create audit CLI and minimal viewer.
+- Document privacy considerations and retention window.
+
+## Definition of Done
+- Random audit of 20 samples reconstructs evidence correctly.
+- PII redaction verified when applicable.
+
+## Related Features
+LLM-001, EXP-001

--- a/backlog/stories/impl/llm_backlog/llm/03-entity-resolution.md
+++ b/backlog/stories/impl/llm_backlog/llm/03-entity-resolution.md
@@ -1,0 +1,45 @@
+---
+id: LLM-003
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: medium
+estimate: 2sp
+dependencies: [ING-001]
+tags: [llm, entity-resolution]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: entity_resolver
+  layer: Bronze
+  input_path: data/bronze/news/
+  notes: Map mentions to canonical team/player ids
+---
+
+# LLM-003: Entity resolution for teams and players
+
+- **Overview**: As a data engineer, I want robust entity resolution so that names in text match our canonical IDs for teams and players.
+- **Value Proposition**: Enables joins across news, odds, schedules, and stats without leaks or mismatches.
+
+## Acceptance Criteria
+- Dictionary-driven resolver supports aliases, abbreviations, and common misspellings.
+- Resolver outputs `entity_id`, `confidence`, and `canonical_name`; abstains when <0.8 confidence.
+- Stored lookups in `data/silver/entities.parquet`; unit tests cover 100+ variants.
+
+## Technical Requirements
+- Fuzzy matching (Jaro-Winkler), token set ratio, and abbreviation maps.
+- Team code dictionary maintained under `config/teams.yml`.
+- Player mapping seeded from public rosters; add-update pipeline.
+
+## Implementation Plan
+- Implement resolver with scoring and thresholds.
+- Build test corpus of tricky aliases.
+- Integrate into news pipeline and LLM features.
+
+## Definition of Done
+- Resolution accuracy ≥ 95% on test set.
+- Unknowns correctly abstained and logged for review.
+
+## Related Features
+ING-002, LLM-001, MOD-002

--- a/backlog/stories/impl/llm_backlog/llm/04-regime-change-detection.md
+++ b/backlog/stories/impl/llm_backlog/llm/04-regime-change-detection.md
@@ -1,0 +1,45 @@
+---
+id: LLM-004
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: medium
+estimate: 3sp
+dependencies: [LLM-001, LLM-003]
+tags: [llm, regime-detection]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: regime_detector
+  layer: Gold
+  input_path: data/silver/llm_signals/
+  notes: Weekly summaries and regime-change flags
+---
+
+# LLM-004: Regime-change detection from weekly summaries
+
+- **Overview**: As a modeler, I want the system to flag scheme/QB/coaching changes so that model priors adjust when the underlying team changes.
+- **Value Proposition**: Prevents stale season-long assumptions from dominating predictions when context flips.
+
+## Acceptance Criteria
+- LLM tags weekly team summaries with `regime_change` boolean and category (e.g., QB change, OC tendency shift).
+- Downstream pipeline widens uncertainty or shifts priors when flagged.
+- Audit view shows before/after feature deltas for flagged teams.
+
+## Technical Requirements
+- Prompt LLM with rolling team reports (last 3 weeks).
+- Simple rules to widen prediction intervals or adjust weights in stacker.
+- Store flags in `data/gold/regime_flags.parquet`.
+
+## Implementation Plan
+- Generate weekly summaries per team.
+- Design prompt and schema for flags.
+- Wire into meta-model weight selection (see MOD-002).
+
+## Definition of Done
+- At least 10 historical known regime flips are detected in backtest.
+- Downstream variance responds as expected in flagged weeks.
+
+## Related Features
+MOD-002, EVAL-002

--- a/backlog/stories/impl/llm_backlog/llm/05-injury-override-signal.md
+++ b/backlog/stories/impl/llm_backlog/llm/05-injury-override-signal.md
@@ -1,0 +1,45 @@
+---
+id: LLM-005
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: high
+estimate: 2sp
+dependencies: [NFL_PLAYER_INJURY_DATA_INTEGRATION]
+tags: [llm, injuries]
+market: null
+layer: Silver
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: injury_override
+  layer: Silver
+  input_path: data/silver/injuries/
+  notes: Overrides or supplements official injury feeds with LLM signal
+---
+
+# LLM-005: Injury override & starter availability signal
+
+- **Overview**: As a handicapper, I want a quantified probability of key starters playing so that preseason and injury-heavy weeks are modeled correctly.
+- **Value Proposition**: Starter availability is the single biggest preseason lever; quantifying it improves predictions and bet selection.
+
+## Acceptance Criteria
+- For QB/RB/WR1/WR2/TE1/LT/EDGE1/CB1 positions, compute `p_play` and `snap_tier`.
+- Signal TTL is 24h unless refreshed by newer news.
+- Models can query `p_play` by player/team and adjust expected efficiency.
+
+## Technical Requirements
+- Derive from LLM outputs with schema validation and hysteresis (don’t flip-flop on tiny news).
+- Persist player-level signals under `data/gold/player_availability.parquet`.
+- Feature functions map player-level to team-level effects.
+
+## Implementation Plan
+- Add position taxonomy and mapping to starters.
+- Implement hysteresis and TTL logic.
+- Join into feature store for predictions.
+
+## Definition of Done
+- Historical audit shows fewer false-start assumptions vs baseline.
+- Models with this signal outperform in preseason backtests.
+
+## Related Features
+LLM-001, MOD-001, MOD-002

--- a/backlog/stories/impl/llm_backlog/llm/06-batch-processing-optimization.md
+++ b/backlog/stories/impl/llm_backlog/llm/06-batch-processing-optimization.md
@@ -1,0 +1,54 @@
+---
+id: LLM-006
+epic: llm_backlog
+status: draft
+owner: team-llm
+priority: medium
+estimate: 2sp
+dependencies: [LLM-001, INF-003]
+tags: [llm, optimization, batch]
+market: null
+layer: Silver
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: llm_batch
+  layer: Silver
+  input_path: data/silver/news_clean/
+  notes: Optimized batch processing for LLM features
+---
+
+# LLM-006: Batch processing optimization for LLM features
+
+- **Overview**: As a platform engineer, I want efficient batch processing for LLM features so that we can process hundreds of articles cost-effectively.
+- **Value Proposition**: Reduces LLM API costs by 40-60% through batching and reduces processing time through parallelization.
+
+## Acceptance Criteria
+- Batch processing of articles with optimal batch sizes per LLM provider
+- Parallel processing with configurable concurrency limits
+- Smart batching that groups similar articles to improve context efficiency
+- Progress tracking and resumable processing for large batches
+- Cost optimization through batch size and provider selection
+
+## Technical Requirements
+- Async processing framework supporting multiple concurrent LLM calls
+- Intelligent batching algorithm considering article similarity and context limits
+- Progress persistence to enable resumable processing after failures
+- Dynamic batch size optimization based on provider performance
+- Integration with caching system to avoid reprocessing
+
+## Implementation Plan
+1. **Design batch processing architecture** with async workers and job queues
+2. **Implement intelligent batching** based on article clustering and context limits
+3. **Add progress tracking** with resumable processing capabilities
+4. **Optimize batch sizes** dynamically based on provider performance
+5. **Integrate with caching** to maximize efficiency
+
+## Definition of Done
+- [ ] Process 500+ articles in <2 hours with standard LLM provider limits
+- [ ] 40%+ cost reduction vs sequential processing
+- [ ] Resumable processing survives worker failures
+- [ ] Batch size optimization improves throughput by 25%+
+- [ ] Integration with existing caching reduces redundant calls
+
+## Related Features
+LLM-001, INF-003, INF-005

--- a/backlog/stories/impl/llm_backlog/modeling/01-base-ats-model.md
+++ b/backlog/stories/impl/llm_backlog/modeling/01-base-ats-model.md
@@ -1,0 +1,46 @@
+---
+id: MOD-001
+epic: llm_backlog
+status: draft
+owner: modeling-team
+priority: high
+estimate: 5sp
+dependencies: [LLM-001, ING-002]
+tags: [modeling, ats]
+market: ats
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: base_ats_model
+  layer: Gold
+  input_path: data/gold/
+  notes: Rebaseline ATS/ML/Total models with clean features
+---
+
+# MOD-001: Rebaseline ATS/ML/Total models with clean features
+
+- **Overview**: As a data scientist, I want strong base models so that LLM signals can add lift on top of a solid foundation.
+- **Value Proposition**: Good baselines ensure we don’t attribute spurious gains to LLM features.
+
+## Acceptance Criteria
+- Train baseline models for ATS, ML, and Totals using rolling features (last-5, last-10, season-to-date).
+- Cross-validation with season/week grouped splits; log-loss/Brier reported.
+- Feature store schema stable and documented.
+
+## Technical Requirements
+- LightGBM/XGBoost with monotonic constraints where applicable.
+- Leak checks (no future odds/stats leakage).
+- Feature store under `data/gold/features.parquet` keyed by `game_id, team_id`.
+
+## Implementation Plan
+- Define feature set and labels per market.
+- Implement grouped CV and evaluation.
+- Store calibrated outputs for stacker input.
+
+## Definition of Done
+- Reproducible training run with fixed seeds.
+- Metrics recorded in `reports/metrics_baseline.md`.
+- Model artifacts versioned under `models/baseline/`.
+
+## Related Features
+EVAL-001, MOD-002

--- a/backlog/stories/impl/llm_backlog/modeling/02-stacker-meta-model.md
+++ b/backlog/stories/impl/llm_backlog/modeling/02-stacker-meta-model.md
@@ -1,0 +1,45 @@
+---
+id: MOD-002
+epic: llm_backlog
+status: draft
+owner: modeling-team
+priority: medium
+estimate: 5sp
+dependencies: [MOD-001]
+tags: [modeling, stacking]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: stacker_model
+  layer: Gold
+  input_path: models/
+  notes: Meta-model stacker with LLM-aware weighting
+---
+
+# MOD-002: Meta-model stacker with LLM-aware weighting
+
+- **Overview**: As a modeler, I want a stacker to blend base models with market info and LLM signals so that predictions adapt to context.
+- **Value Proposition**: Combines numeric strength with text-derived situational awareness.
+
+## Acceptance Criteria
+- Inputs: base model probs, market implied probs, selected LLM signals.
+- Outputs calibrated probabilities for ATS/ML/Total; weights logged per game.
+- Ablation shows improvement vs baselines ≥ 2% Brier reduction.
+
+## Technical Requirements
+- Logistic regression or shallow GBM; optional LLM advisory that outputs weight priors.
+- Isotonic/Platt calibration over validation folds.
+- Explainability: per-game breakdown of contributing inputs.
+
+## Implementation Plan
+- Implement stacker fit/predict API.
+- Join features; run CV with and without LLM signals.
+- Persist calibrated outputs; add SHAP-like summary or weight table.
+
+## Definition of Done
+- Ablation report written to `reports/ablation_stacker.md`.
+- Per-game logs include component weights and final prob.
+
+## Related Features
+LLM-001, EVAL-002, MOD-001

--- a/backlog/stories/impl/llm_backlog/modeling/03-probability-calibration.md
+++ b/backlog/stories/impl/llm_backlog/modeling/03-probability-calibration.md
@@ -1,0 +1,45 @@
+---
+id: MOD-003
+epic: llm_backlog
+status: draft
+owner: modeling-team
+priority: medium
+estimate: 3sp
+dependencies: [MOD-001]
+tags: [modeling, calibration]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: calibration
+  layer: Gold
+  input_path: models/calibration/
+  notes: Probability calibration & reliability curves
+---
+
+# MOD-003: Probability calibration & reliability curves
+
+- **Overview**: As a quant, I want calibrated probabilities so that our 60% means 60% in the long run.
+- **Value Proposition**: Calibration improves bankroll management and trust in the system.
+
+## Acceptance Criteria
+- Reliability plots for ATS/ML/Total created for baseline and stacker.
+- Isotonic regression selected unless sample size too small (fallback to Platt).
+- Calibration error reported and tracked over time.
+
+## Technical Requirements
+- Bin-based reliability and Brier decomposition.
+- Store calibration maps with model metadata.
+- Unit tests for calibration functions.
+
+## Implementation Plan
+- Implement calibration utilities.
+- Integrate into training and inference pipelines.
+- Generate plots and tables in `reports/`.
+
+## Definition of Done
+- Plots and metrics present; CI test covers calibration edge cases.
+- Inference applies correct calibration map for model version.
+
+## Related Features
+MOD-001, MOD-002, EVAL-001

--- a/backlog/stories/impl/llm_backlog/modeling/04-abstention-logic.md
+++ b/backlog/stories/impl/llm_backlog/modeling/04-abstention-logic.md
@@ -1,0 +1,45 @@
+---
+id: MOD-004
+epic: llm_backlog
+status: draft
+owner: modeling-team
+priority: medium
+estimate: 3sp
+dependencies: [MOD-003]
+tags: [modeling, abstention]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: abstention_logic
+  layer: Gold
+  input_path: models/abstention/
+  notes: Abstention and do-not-bet rules
+---
+
+# MOD-004: Abstention and do-not-bet logic
+
+- **Overview**: As a bettor, I want the system to pass on low-information or contradictory games so that we avoid negative-EV spots.
+- **Value Proposition**: Fewer forced bets, higher realized edge.
+
+## Acceptance Criteria
+- Rules: abstain when LLM signals conflict or regime change flagged + high uncertainty.
+- Minimum edge thresholds configurable per market (e.g., ≥ 2.5% over market).
+- UI shows reason for abstention.
+
+## Technical Requirements
+- Edge computation vs vig-adjusted market probs.
+- Uncertainty from model variance and LLM signal confidence.
+- Expose `abstain_reason` in output API.
+
+## Implementation Plan
+- Define rules and thresholds; implement evaluator.
+- Integrate into pick selection and UI display.
+- Add tests for abstention scenarios.
+
+## Definition of Done
+- Backtest shows improved Sharpe and lower drawdowns.
+- UI surfaces clear abstain reasons.
+
+## Related Features
+LLM-004, UI-002

--- a/backlog/stories/impl/llm_backlog/modeling/05-feature-store-schema.md
+++ b/backlog/stories/impl/llm_backlog/modeling/05-feature-store-schema.md
@@ -1,0 +1,45 @@
+---
+id: MOD-005
+epic: llm_backlog
+status: draft
+owner: feature-store-team
+priority: high
+estimate: 4sp
+dependencies: []
+tags: [feature-store, schema]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: feature_store_schema
+  layer: Gold
+  input_path: data/gold/
+  notes: Feature store schema & lineage
+---
+
+# MOD-005: Feature store schema & lineage
+
+- **Overview**: As a platform engineer, I want a documented feature store so that features are reusable and auditable.
+- **Value Proposition**: Prevents one-off features and speeds iteration.
+
+## Acceptance Criteria
+- Schema includes sources: numeric, market, and LLM-derived features.
+- Lineage tracked from raw → silver → gold with versioning.
+- Data dictionary produced under `docs/feature_store.md`.
+
+## Technical Requirements
+- Use Parquet + Delta-like partitioning by date/week where useful.
+- Add `as_of` timestamps and TTLs for time-sensitive LLM features.
+- Great Expectations or pandera checks for critical columns.
+
+## Implementation Plan
+- Design table(s) and write loaders.
+- Implement validation checks and CI step.
+- Document dictionary and sample queries.
+
+## Definition of Done
+- Validation passes on full pipeline run.
+- Docs up to date; joins work across sources.
+
+## Related Features
+ING-*, LLM-*, MOD-*

--- a/backlog/stories/impl/llm_backlog/modeling/06-calibration-monitoring.md
+++ b/backlog/stories/impl/llm_backlog/modeling/06-calibration-monitoring.md
@@ -1,0 +1,54 @@
+---
+id: MOD-006
+epic: llm_backlog
+status: draft
+owner: modeling-team
+priority: high
+estimate: 2sp
+dependencies: [MOD-001, MOD-002, EVAL-001]
+tags: [modeling, monitoring, calibration]
+market: null
+layer: Analysis
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: model_monitoring
+  layer: Analysis
+  input_path: data/analysis/
+  notes: Production model calibration and performance monitoring
+---
+
+# MOD-006: Production model calibration monitoring
+
+- **Overview**: As a modeling team member, I want continuous monitoring of model calibration so that prediction confidence remains accurate over time.
+- **Value Proposition**: Maintains betting edge by detecting when models become overconfident or underconfident before significant losses occur.
+
+## Acceptance Criteria
+- Real-time calibration monitoring using Brier score decomposition and reliability curves
+- Alert when calibration error exceeds threshold (>0.05 for critical markets)
+- Weekly calibration reports with trend analysis and recommended actions
+- Integration with prediction pipeline to flag poorly calibrated periods
+- Automatic model retraining triggers when calibration degrades significantly
+
+## Technical Requirements
+- Streaming calibration metrics computed on live predictions vs outcomes
+- Statistical significance testing for calibration changes
+- Integration with existing model evaluation framework (EVAL-001)
+- Dashboard showing calibration trends across markets and time periods
+- Automated alerting system with severity levels and recommended actions
+
+## Implementation Plan
+1. **Implement streaming calibration metrics** with rolling window calculations
+2. **Create calibration monitoring dashboard** with historical trends
+3. **Add automated alerting** for calibration degradation with action recommendations
+4. **Integrate with prediction pipeline** to flag poorly calibrated periods
+5. **Connect to retraining triggers** for automatic model updates
+
+## Definition of Done
+- [ ] Calibration metrics updated within 24 hours of new outcomes
+- [ ] Alerts trigger when calibration error exceeds 0.05 for >7 days
+- [ ] Weekly calibration reports generated automatically
+- [ ] Dashboard shows calibration trends across all active models
+- [ ] Integration with model retraining pipeline for automated updates
+
+## Related Features
+MOD-001, MOD-002, MOD-003, EVAL-001, QLT-003

--- a/backlog/stories/impl/llm_backlog/quality/01-data-quality-checks.md
+++ b/backlog/stories/impl/llm_backlog/quality/01-data-quality-checks.md
@@ -1,0 +1,44 @@
+---
+id: QLT-001
+epic: llm_backlog
+status: draft
+owner: qa-team
+priority: high
+estimate: 2sp
+dependencies: []
+tags: [quality, data]
+market: null
+layer: Bronze
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: dq_checks
+  layer: Bronze
+  input_path: data/bronze/
+  notes: Data quality checks on joins and keys
+---
+
+# QLT-001: Data quality checks on joins and keys
+
+- **Overview**: As a data engineer, I want quality checks on join keys so that mismatches are caught early.
+- **Value Proposition**: Prevents silent data loss or duplication from mis-joins.
+
+## Acceptance Criteria
+- Checks for duplicate `game_id` rows; one-to-one joins validated between schedules, odds, and features.
+- Missing keys reported with counts and sample rows.
+- CI gate fails if key error rate exceeds threshold.
+
+## Technical Requirements
+- pandera/Great Expectations suite executed in CI.
+- Per-source completeness stats logged.
+
+## Implementation Plan
+- Define expectations for each table.
+- Implement CI step.
+- Create sample failing tests to verify gating.
+
+## Definition of Done
+- Quality report produced for each run.
+- CI blocks on violations as configured.
+
+## Related Features
+ING-*, MOD-*

--- a/backlog/stories/impl/llm_backlog/quality/02-logging-and-monitoring.md
+++ b/backlog/stories/impl/llm_backlog/quality/02-logging-and-monitoring.md
@@ -1,0 +1,45 @@
+---
+id: QLT-002
+epic: llm_backlog
+status: draft
+owner: qa-team
+priority: medium
+estimate: 2sp
+dependencies: []
+tags: [logging, monitoring]
+market: null
+layer: Infra
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: logging_monitoring
+  layer: Infra
+  input_path: logs/
+  notes: Structured logging & lightweight monitoring
+---
+
+# QLT-002: Structured logging & lightweight monitoring
+
+- **Overview**: As an operator, I want structured logs and simple dashboards so that I can spot failures and slowdowns.
+- **Value Proposition**: Cuts time-to-detect and time-to-fix for pipeline issues.
+
+## Acceptance Criteria
+- All jobs emit structured logs (JSON) including timing, counts, and error summaries.
+- Basic dashboard (e.g., local Streamlit or simple HTML) shows last runs and KPIs.
+- Alerts for repeated failures or missing new data for >6h.
+
+## Technical Requirements
+- Python `logging` with JSON formatter; logrotate/size caps.
+- Small status page reading from `data/logs/` artifacts.
+- Optional webhook/email for alerts (configurable).
+
+## Implementation Plan
+- Add logging utilities and context IDs.
+- Create status page and simple alert hooks.
+- Document ops playbook for common errors.
+
+## Definition of Done
+- Status page reflects latest run; alert fires on simulated failure.
+- Logs searchable and compact.
+
+## Related Features
+INF-002, ING-*, LLM-*

--- a/backlog/stories/impl/llm_backlog/quality/03-feature-monitoring-drift.md
+++ b/backlog/stories/impl/llm_backlog/quality/03-feature-monitoring-drift.md
@@ -1,0 +1,54 @@
+---
+id: QLT-003
+epic: llm_backlog
+status: draft
+owner: qa-team
+priority: high
+estimate: 3sp
+dependencies: [MOD-005]
+tags: [quality, monitoring, drift]
+market: null
+layer: Gold
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: feature_monitoring
+  layer: Gold
+  input_path: data/gold/
+  notes: Real-time feature store monitoring and alerting
+---
+
+# QLT-003: Feature store monitoring and drift detection
+
+- **Overview**: As a data scientist, I want real-time monitoring of feature quality and drift so that model degradation is detected before it impacts predictions.
+- **Value Proposition**: Prevents silent model failures by catching data quality issues, feature drift, and pipeline breakages early.
+
+## Acceptance Criteria
+- Monitor feature completeness, distribution shifts, and correlation changes
+- Alert on feature freshness violations (e.g., LLM features >24h old)
+- Drift detection using statistical tests (KS test, PSI) with configurable thresholds
+- Dashboard showing feature health status across all data sources
+- Integration with model performance monitoring to correlate drift with accuracy
+
+## Technical Requirements
+- Real-time feature quality metrics computed during pipeline execution
+- Statistical drift detection with baseline period and rolling windows
+- Configurable alerting via email/Slack with severity levels
+- Historical trend tracking for all monitored features
+- Integration with existing logging infrastructure (QLT-002)
+
+## Implementation Plan
+1. **Define feature quality metrics** (completeness, distribution, correlations)
+2. **Implement drift detection** algorithms with baseline establishment
+3. **Create monitoring dashboard** showing real-time feature health
+4. **Add alerting system** with configurable thresholds and notifications
+5. **Integrate with model monitoring** to correlate drift with performance
+
+## Definition of Done
+- [ ] All critical features monitored for drift and quality
+- [ ] Alerts trigger within 1 hour of significant drift detection
+- [ ] Dashboard provides clear feature health overview
+- [ ] Historical drift trends tracked and queryable
+- [ ] False positive rate <10% on drift alerts
+
+## Related Features
+MOD-005, QLT-001, QLT-002, EVAL-001

--- a/backlog/stories/impl/llm_backlog/ui/01-landing-page-cards.md
+++ b/backlog/stories/impl/llm_backlog/ui/01-landing-page-cards.md
@@ -1,0 +1,45 @@
+---
+id: UI-001
+epic: llm_backlog
+status: draft
+owner: ui-team
+priority: medium
+estimate: 3sp
+dependencies: [LLM-001]
+tags: [ui, landing]
+market: moneyline
+layer: Web
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: ui_cards
+  layer: Web
+  input_path: web_build/data/
+  notes: Landing page with daily games & confidence
+---
+
+# UI-001: Landing page with daily games & confidence
+
+- **Overview**: As a user, I want a dashboard of today’s games with confidence and edges so that I can quickly scan opportunities.
+- **Value Proposition**: Speeds decision-making and highlights top value bets.
+
+## Acceptance Criteria
+- List games for selected date; show ATS/ML/Total confidence, market line, model line, and edge.
+- Filters: market type, minimum edge, hide abstains.
+- Responsive; accessible; basic keyboard nav.
+
+## Technical Requirements
+- Static site (HTML/CSS/JS) consuming a JSON endpoint from the pipeline outputs.
+- Simple client-side sorting and filtering.
+- Dark mode support.
+
+## Implementation Plan
+- Define output JSON contract from inference pipeline.
+- Build static UI and wire filters.
+- Add smoke tests with sample data.
+
+## Definition of Done
+- Renders with fixture JSON; Lighthouse performance ≥ 90.
+- Cross-browser check on latest Chrome/Firefox/Edge.
+
+## Related Features
+UI-002, MOD-004

--- a/backlog/stories/impl/llm_backlog/ui/02-game-detail-page.md
+++ b/backlog/stories/impl/llm_backlog/ui/02-game-detail-page.md
@@ -1,0 +1,45 @@
+---
+id: UI-002
+epic: llm_backlog
+status: draft
+owner: ui-team
+priority: medium
+estimate: 3sp
+dependencies: [LLM-002, UI-001]
+tags: [ui, game-detail]
+market: moneyline
+layer: Web
+last_updated: 2025-08-24
+emit_metadata:
+  source_id: game_detail_ui
+  layer: Web
+  input_path: web_build/predictions/
+  notes: Game detail page with rationale and signals
+---
+
+# UI-002: Game detail page with rationale and signals
+
+- **Overview**: As a user, I want a per-game detail view so that I can see why a pick is recommended.
+- **Value Proposition**: Transparency improves trust and lets power users dig in.
+
+## Acceptance Criteria
+- Show calibrated probabilities, edges vs market, top contributing features.
+- Display LLM evidence quotes with links; show abstain reasons when applicable.
+- Export view as PDF with timestamp and model version.
+
+## Technical Requirements
+- Client renders explanation JSON and evidence list.
+- Print CSS for PDF; include watermark with model version.
+- Error states for missing data.
+
+## Implementation Plan
+- Define JSON for detail view (EXP-001).
+- Build components and routing.
+- Add export-to-PDF button.
+
+## Definition of Done
+- Detail view matches sample; PDF export verified.
+- Unit tests for rendering edge cases.
+
+## Related Features
+EXP-001, MOD-002, LLM-002

--- a/backlog/stories/impl/social_media/README.md
+++ b/backlog/stories/impl/social_media/README.md
@@ -1,0 +1,77 @@
+# Social Media Sources — User Stories
+
+**Generated:** 2025-08-24 13:59:19  
+**Refined:** 2025-08-24 (Updated for current architecture)
+
+This collection contains 12 ready-to-implement user stories for adding Twitter/X and Bluesky as social news sources to the NFL Predictions project.
+
+## Architecture Alignment
+
+These stories align with our current **9-layer data architecture**:
+- **Raw Layer**: JSON social posts from APIs
+- **Bronze Layer**: Normalized `SocialPost` schema 
+- **Silver Layer**: Deduplicated, entity-linked posts
+- **Gold Layer**: Relevance-filtered, ML-ready features
+
+## Story Overview
+
+### Foundation (S01-S02)
+- **S01**: Core `SocialPost` schema and provider abstraction
+- **S02**: Twitter/X curated account ingestion
+
+### Data Collection (S03-S05)  
+- **S03**: Twitter/X keyword and list search
+- **S04**: Bluesky curated handles ingestion
+- **S05**: Bluesky keyword and graph search
+
+### Processing Pipeline (S06-S08)
+- **S06**: Relevance filtering and entity linking
+- **S07**: Deduplication and cross-platform post collapsing
+- **S08**: Scheduling, rate limits, and checkpointing
+
+### Operations (S09-S11)
+- **S09**: Feed health metrics and alerting
+- **S10**: Compliance, configuration gating, and kill switches
+- **S11**: UI/CLI for source configuration
+
+### Evaluation (S12)
+- **S12**: Measuring social signal lift in predictions
+
+## Integration with Current System
+
+### CLI Integration
+Stories integrate with our `busta` CLI pattern:
+```bash
+busta pipeline collect social --provider x
+busta pipeline collect social --provider bluesky
+busta features --include-social  # Future enhancement
+```
+
+### Configuration
+Extends our existing YAML config system:
+- `config/social_sources.yaml` - Social platform configuration
+- `config/entities.yaml` - NFL entity recognition
+
+### Storage Layout
+Follows our established data lake structure:
+```
+data/
+├── raw/social/{x|bluesky}/YYYY/MM/DD/*.jsonl
+├── bronze/social_posts/*.parquet  
+├── silver/social_posts_processed/*.parquet
+└── gold/social_features/*.parquet
+```
+
+## Implementation Priority
+
+**Phase 1** (Foundation): S01, S02, S06  
+**Phase 2** (Expansion): S03, S04, S08  
+**Phase 3** (Operations): S07, S09, S10, S11  
+**Phase 4** (Evaluation): S05, S12
+
+## Next Steps
+
+1. **Review and approve** stories in this PR
+2. **Create tracking issues** for each story
+3. **Begin implementation** with Phase 1 stories
+4. **Update project backlog** with social media roadmap

--- a/backlog/stories/impl/social_media/S01_social_news_schema_and_abstraction.md
+++ b/backlog/stories/impl/social_media/S01_social_news_schema_and_abstraction.md
@@ -1,0 +1,38 @@
+# Story S01 — Social News Schema & Abstraction
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a data engineer, I want a unified social-news schema and source interface so that Twitter/X and Bluesky posts can flow through the same pipeline as RSS with minimal branching.
+
+## Value Proposition
+Reduces one-off logic, speeds integration of future sources, and simplifies downstream features (sentiment, entity linking, dedupe).
+
+## Acceptance Criteria
+- A new `SocialPost` domain model aligns with existing `NewsItem` fields where applicable: `id`, `published_at`, `url`, `source`, `author`, `text`, `language`, `engagement`, `entities`, `media`.
+- Provider mappers for X and Bluesky populate this model; unit tests cover null/optional fields.
+- Serialization supported to JSONL & Parquet; timestamps normalized to UTC; language codes normalized (ISO 639-1).
+- Linting (ruff), typing (mypy) pass in CI.
+
+## Technical Requirements
+- Files:
+  - `packages/data_pipeline/src/nfl_data_pipeline/sources/social_common.py` (interfaces, dataclasses or pydantic models)
+  - `packages/data_pipeline/src/nfl_data_pipeline/transform/social_mapper.py` (provider→domain mappers)
+  - `packages/data_pipeline/tests/test_social_schema.py`
+- Storage layout:
+  - Raw: `data/raw/social/{x|bluesky}/YYYY/MM/DD/*.jsonl`
+  - Bronze (normalized): `data/bronze/social_posts/*.parquet`
+
+## Implementation Plan
+1. Define `SocialPost` with typed fields & validators (UTC coercion, ISO language codes, safe ints for counts).
+2. Write shared helpers (emoji/hashtag normalization, URL expansion placeholder).
+3. Create provider mappers returning `SocialPost` instances.
+4. Wire bronze writer and add CI coverage.
+
+## Definition of Done
+- >90% test coverage on schema & mappers.
+- `ruff`, `mypy` clean; docs added at `docs/ingestion/social.md`.
+- Example JSONL→Parquet flow demonstrated with fixture payloads.
+
+## Related Features
+RSS `NewsItem` pipeline; sentiment; entity tagging; dedupe.

--- a/backlog/stories/impl/social_media/S02_x_curated_accounts_ingestion.md
+++ b/backlog/stories/impl/social_media/S02_x_curated_accounts_ingestion.md
@@ -1,0 +1,35 @@
+# Story S02 — Twitter/X: Curated Accounts Ingestion
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a data collector, I want to ingest posts from a curated list of NFL accounts on X so that beat writers and team announcements enter the news stream quickly.
+
+## Value Proposition
+High-signal, low-noise firehose from trusted voices; better injury/lineup detection.
+
+## Acceptance Criteria
+- Given valid X credentials, the job pulls latest posts for configured handles since last run.
+- Configurable per-run max posts, lookback window, and `include_retweets` / `include_replies` toggles.
+- Writes raw JSONL and normalized `SocialPost` to bronze; idempotent re-runs (no duplicates).
+- Basic engagement fields recorded (like/repost/reply counts if available).
+
+## Technical Requirements
+- Files:
+  - `packages/data_pipeline/src/nfl_data_pipeline/sources/social_x.py`
+  - `config/social_sources.yaml` (`x.accounts`, `x.options`, rate-limit params)
+- CLI: `busta pipeline collect social --provider x`
+- Rate-limit/backoff & checkpointing (`state/social_x.json`).
+
+## Implementation Plan
+1. Add config loader for `x.accounts` (handles) and options.
+2. Implement fetch loop with pagination + `since_id` checkpoint.
+3. Map to `SocialPost`; persist raw & bronze; de-dup by provider id.
+4. Add minimal unit tests with recorded fixtures.
+
+## Definition of Done
+- Dry-run against 3–5 public NFL accounts; sample rows visible in `busta pipeline report feeds`.
+- State file advances across runs and prevents refetching.
+
+## Related Features
+Health checks; dedupe; entity linking; schema (S01).

--- a/backlog/stories/impl/social_media/S03_x_keyword_and_list_search.md
+++ b/backlog/stories/impl/social_media/S03_x_keyword_and_list_search.md
@@ -1,0 +1,30 @@
+# Story S03 — Twitter/X: Keyword & List Search
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As an analyst, I want keyword and list-based search on X so that we capture breaking news beyond the curated handles.
+
+## Value Proposition
+Broader coverage for emergent stories (injuries, trades, suspensions).
+
+## Acceptance Criteria
+- Config supports `x.search.queries` with boolean operators and required hashtags/mentions.
+- Per-query limits and cooldowns; language filter enforced.
+- Posts pass relevance filter (teams/players/league terms) before normalization.
+
+## Technical Requirements
+- Extend `social_x.py` with search client.
+- Enforce cool-downs by query; `state/social_x_search.json` for per-query cursors.
+- Integration with `relevance_filter.py` (S06).
+
+## Implementation Plan
+1. Add search iterator with paging & `since_time`/`since_id` as supported.
+2. Integrate relevance filter prior to bronze write.
+3. Tests: query parsing, rate-limit handling, and dedupe with S07.
+
+## Definition of Done
+- At least one query per division returns posts; noise rate <30% in manual sample review.
+
+## Related Features
+Relevance filter (S06); moderation; dedupe (S07).

--- a/backlog/stories/impl/social_media/S04_bluesky_curated_handles_ingestion.md
+++ b/backlog/stories/impl/social_media/S04_bluesky_curated_handles_ingestion.md
@@ -1,0 +1,30 @@
+# Story S04 — Bluesky: Curated Handles Ingestion
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a data collector, I want to ingest Bluesky posts from specific handles so that we don’t miss reporters who migrated away from X.
+
+## Value Proposition
+Diversifies coverage; resilience against single-platform outages/policy changes.
+
+## Acceptance Criteria
+- Given Bluesky credentials or app-password, fetch latest posts from configured DIDs/handles.
+- Raw & bronze written; idempotent with cursor checkpointing.
+- Media URLs captured when present; links resolved where possible.
+
+## Technical Requirements
+- Files: `packages/data_pipeline/src/nfl_data_pipeline/sources/social_bluesky.py`
+- Config: `bluesky.accounts` and `bluesky.options` in `config/social_sources.yaml`.
+- Support REST feed endpoints; optional firehose toggle (future).
+
+## Implementation Plan
+1. Add client wrapper with pagination + cursor state.
+2. Map payloads to `SocialPost` with link/media extraction.
+3. Add fixtures + unit tests; ensure UTC normalization.
+
+## Definition of Done
+- Sample run over 3–5 NFL reporters; records visible in bronze; checkpoint persists.
+
+## Related Features
+Social schema (S01); health checks (S09).

--- a/backlog/stories/impl/social_media/S05_bluesky_keyword_and_graph_search.md
+++ b/backlog/stories/impl/social_media/S05_bluesky_keyword_and_graph_search.md
@@ -1,0 +1,30 @@
+# Story S05 — Bluesky: Keyword/Graph Search
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As an analyst, I want keyword/hashtag search and simple graph expansion (followers of curated handles) on Bluesky to catch breaking items.
+
+## Value Proposition
+Captures emergent accounts and stories; improves recall.
+
+## Acceptance Criteria
+- Configurable `bluesky.search.queries` & optional “followees of” expansion.
+- Relevance filter applied pre-persist; per-query rate-limit respected.
+- Prevent uncontrolled growth of expanded handle set.
+
+## Technical Requirements
+- Extend `social_bluesky.py` with search and basic graph lookup.
+- State tracking for expanded handles to avoid unbounded growth.
+- Integration with relevance filter (S06).
+
+## Implementation Plan
+1. Implement search iterator; add simple “expand once” cache with TTL.
+2. Integrate with S06 filter & S09 health logging.
+3. Tests for graph expansion boundaries and state persistence.
+
+## Definition of Done
+- At least one query returns relevant posts across 2+ days; no explosion in handle count.
+
+## Related Features
+Relevance filter (S06); dedupe (S07); health (S09).

--- a/backlog/stories/impl/social_media/S06_relevance_filter_and_entity_linking.md
+++ b/backlog/stories/impl/social_media/S06_relevance_filter_and_entity_linking.md
@@ -1,0 +1,31 @@
+# Story S06 — Relevance Filter & Entity Linking for Social
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a feature engineer, I want to filter and enrich social posts with detected teams/players so that only NFL-relevant content flows downstream.
+
+## Value Proposition
+Cuts noise; enables per-team feeds and model features (injury/lineup mentions).
+
+## Acceptance Criteria
+- Dictionary-driven matcher for team names, nicknames, tickers, player aliases.
+- Optional simple NER (spaCy or rule-based) for player names; confidence score per post.
+- Posts tagged with `teams[]`, `players[]`; off-topic posts dropped if below threshold.
+- Unit tests cover ambiguous names (e.g., “Giants”), emojis, and hashtags.
+
+## Technical Requirements
+- Files: `packages/data_pipeline/src/nfl_data_pipeline/transform/relevance_filter.py`
+- Config: `config/entities.yaml` (teams, aliases, stopwords).
+- Optional dependency on spaCy small English model if enabled.
+
+## Implementation Plan
+1. Build token-normalized matcher; add emoji & hashtag normalization.
+2. Add thresholding and confidence scoring.
+3. Write tests with tricky nicknames and ambiguous city names.
+
+## Definition of Done
+- Precision ≥0.8 on a hand-labeled sample of 200 posts (document sample & results in repo).
+
+## Related Features
+Sentiment; dedupe; search stories (S03, S05).

--- a/backlog/stories/impl/social_media/S07_dedup_and_crosspost_collapsing.md
+++ b/backlog/stories/impl/social_media/S07_dedup_and_crosspost_collapsing.md
@@ -1,0 +1,30 @@
+# Story S07 — De-duplication & Cross-Post Collapsing
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a data engineer, I want to detect duplicates and cross-posts across RSS, X, and Bluesky so that downstream views don’t double-count stories.
+
+## Value Proposition
+Cleaner analytics; saner UI; avoids skewed engagement metrics.
+
+## Acceptance Criteria
+- Exact duplicates by provider id removed; near-dupes collapsed via URL canonicalization + text similarity.
+- Cross-post grouping: link posts that share the same canonical URL or ≥0.9 similarity.
+- `story_group_id` assigned and persisted for grouped items.
+
+## Technical Requirements
+- Files: `packages/data_pipeline/src/nfl_data_pipeline/transform/dedupe.py`
+- Use MinHash or cosine similarity (tf-idf) on normalized text.
+- URL canonicalizer (UTM stripping, t.co expansion).
+
+## Implementation Plan
+1. Implement URL canonicalization utilities with tests.
+2. Implement text cleaning + similarity scoring; tune threshold.
+3. Persist `story_group_id` and verify stable grouping across runs.
+
+## Definition of Done
+- In a mixed sample, duplicate rate reduced by ≥80% vs. raw; tests cover common near-dupe cases.
+
+## Related Features
+Social schema (S01); feed health (S09); UI surfacing.

--- a/backlog/stories/impl/social_media/S08_scheduling_ratelimits_secrets_checkpointing.md
+++ b/backlog/stories/impl/social_media/S08_scheduling_ratelimits_secrets_checkpointing.md
@@ -1,0 +1,31 @@
+# Story S08 — Scheduling, Rate-Limits, Secrets & Checkpointing
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As an operator, I want resilient job scheduling with rate-limit handling and secure secrets so that social ingestion runs reliably.
+
+## Value Proposition
+Fewer failures, no credential leaks, predictable throughput.
+
+## Acceptance Criteria
+- Credentials loaded from `.env`/secret store; never logged.
+- Exponential backoff and jitter on 429/5xx; per-provider QPS limits configurable.
+- Per-handle, per-query checkpoint files; resumable runs.
+
+## Technical Requirements
+- Files:
+  - `packages/data_pipeline/src/nfl_data_pipeline/utils/rate_limit.py`
+  - `packages/data_pipeline/src/nfl_data_pipeline/utils/checkpoint.py`
+- Update `busta` command help & examples.
+
+## Implementation Plan
+1. Implement rate-limit wrapper; integrate in providers.
+2. Add secret loading & validation on startup.
+3. Verify checkpoints via rerun tests.
+
+## Definition of Done
+- Chaos test (forced 429s) passes; checkpoints verified via rerun without refetching.
+
+## Related Features
+Provider ingestion (S02–S05); health checks (S09).

--- a/backlog/stories/impl/social_media/S09_feed_health_metrics_alerting.md
+++ b/backlog/stories/impl/social_media/S09_feed_health_metrics_alerting.md
@@ -1,0 +1,29 @@
+# Story S09 — Feed Health, Metrics & Alerting for Social
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As an SRE, I want health metrics and dashboards for social ingestion so that I can detect stalls, auth failures, and surges.
+
+## Value Proposition
+Faster incident response; better capacity planning.
+
+## Acceptance Criteria
+- Extend `feed_health.py` to track: `last_success_ts`, `items_ingested`, `error_rate`, `avg_latency`, `rate_limit_hits`.
+- CLI report shows social providers & top failing handles/queries.
+- Optional webhook/email alert on stall > N minutes.
+
+## Technical Requirements
+- Files: `packages/data_pipeline/src/nfl_data_pipeline/sources/feed_health.py` (extend)
+- Metrics dump: `data/ops/social_health/*.json`
+
+## Implementation Plan
+1. Add counters & timers around provider calls.
+2. Update `busta pipeline report feeds` to include social section.
+3. Write tests for failure detection and recovery logging.
+
+## Definition of Done
+- Demo report with at least one induced failure and one recovery; metrics visible in JSON dumps.
+
+## Related Features
+Scheduling (S08); provider ingestion (S02–S05).

--- a/backlog/stories/impl/social_media/S10_compliance_config_gating_killswitch.md
+++ b/backlog/stories/impl/social_media/S10_compliance_config_gating_killswitch.md
@@ -1,0 +1,29 @@
+# Story S10 — Compliance, Config Gating & Kill-Switch
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a product owner, I want compliance toggles and a global kill-switch so we can quickly disable a provider if policies or access change.
+
+## Value Proposition
+Risk reduction; easier ops during platform policy shifts.
+
+## Acceptance Criteria
+- Config flags: `enable_x`, `enable_bluesky`, and `social_read_only` mode.
+- `busta pipeline collect social` respects flags; kill-switch halts fetch but keeps transforms/test stubs.
+- Audit log of enable/disable events.
+
+## Technical Requirements
+- Files: `packages/data_pipeline/src/nfl_data_pipeline/config/settings.py` (flags)
+- Audit: `data/ops/audit/social_flags.log`
+
+## Implementation Plan
+1. Add flags & wiring to providers.
+2. Write simple audit appender and test toggling.
+3. Document ops runbook in `docs/ingestion/social.md`.
+
+## Definition of Done
+- Toggling flags changes behavior without code changes; covered by integration tests.
+
+## Related Features
+Scheduling (S08); provider ingestion (S02–S05).

--- a/backlog/stories/impl/social_media/S11_ui_cli_source_configuration.md
+++ b/backlog/stories/impl/social_media/S11_ui_cli_source_configuration.md
@@ -1,0 +1,29 @@
+# Story S11 — UI/CLI Surfacing & Source Configuration
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a user, I want to manage social sources via config and run them from the CLI so I can iterate quickly without code edits.
+
+## Value Proposition
+Developer speed; reproducible runs.
+
+## Acceptance Criteria
+- `config/social_sources.yaml` supports: accounts, queries, language, lookback, limits, include_rt/replies, and per-provider options.
+- CLI examples in README; dry-run flag prints planned calls without hitting APIs.
+- Schema validation errors are friendly and actionable.
+
+## Technical Requirements
+- Files: `config/social_sources.yaml`, `README.md` updates.
+- CLI: `busta pipeline collect social --provider {x|bluesky} --dry-run --since 90m`
+
+## Implementation Plan
+1. Add schema & validation for config (pydantic or voluptuous).
+2. Implement `--dry-run` and `--since` flags.
+3. Provide example config and sample commands in README.
+
+## Definition of Done
+- Example config committed; `busta pipeline collect social --dry-run` shows the plan without network calls.
+
+## Related Features
+Provider ingestion (S02–S05); compliance flags (S10).

--- a/backlog/stories/impl/social_media/S12_evaluation_social_signal_lift.md
+++ b/backlog/stories/impl/social_media/S12_evaluation_social_signal_lift.md
@@ -1,0 +1,29 @@
+# Story S12 — Evaluation: Does Social Improve Predictions?
+
+**Last Updated:** 2025-08-24 13:59:19
+
+## Overview
+As a data scientist, I want to quantify the lift from social signals so that we know whether to keep investing.
+
+## Value Proposition
+Evidence-based prioritization.
+
+## Acceptance Criteria
+- Generate features: social sentiment, volume spikes, injury/transaction keyword counts by team/day.
+- Backtest across historical weeks with/without social features; report delta in validation metrics.
+- Clear go/no-go recommendation captured in markdown with charts.
+
+## Technical Requirements
+- Files: `packages/features/src/social_features.py`, `packages/models/notebooks/social_lift.ipynb`
+- Inputs: bronze social posts + relevance tags; outputs: feature tables and evaluation report.
+
+## Implementation Plan
+1. Feature extraction jobs reading bronze social + relevance tags.
+2. Re-train baseline ATS model with added features; compare performance (AUC/LogLoss/Calibration).
+3. Document results and risks; include follow-up stories if lift is material.
+
+## Definition of Done
+- Markdown report with charts; clear summary of impact and recommendation committed at `docs/reports/social_lift.md`.
+
+## Related Features
+Relevance (S06); sentiment pipeline; modeling.

--- a/backlog/stories/impl/social_media/_examples/social_sources.example.yaml
+++ b/backlog/stories/impl/social_media/_examples/social_sources.example.yaml
@@ -1,0 +1,40 @@
+# Example social_sources.yaml
+x:
+  enabled: true
+  credentials:
+    bearer_token: ${X_BEARER_TOKEN}
+  accounts:
+    - rapSheet
+    - AdamSchefter
+    - JayMorrisonATH
+  options:
+    include_retweets: false
+    include_replies: false
+    lookback_minutes: 90
+    per_account_limit: 100
+  search:
+    queries:
+      - "(injury OR questionable OR out) (Bengals OR CIN)"
+      - "(inactive OR starters) (preseason OR PS)"
+    language: "en"
+    per_query_limit: 200
+    cooldown_seconds: 10
+
+bluesky:
+  enabled: true
+  credentials:
+    handle: ${BLUESKY_HANDLE}
+    app_password: ${BLUESKY_APP_PASSWORD}
+  accounts:
+    - did:plc:replace_me
+    - "replace_me.example"  # Quoted to handle special characters
+  options:
+    lookback_minutes: 90
+    per_account_limit: 100
+  search:
+    queries:
+      - "Bengals injury"
+      - "inactive starters"
+    language: "en"
+    per_query_limit: 200
+    cooldown_seconds: 10


### PR DESCRIPTION
Imports all story files from the implementation repository into backlog/stories/impl/ for planning agent review and organization.

## Summary
- 60 story files migrated from docs/stories/
- Includes llm_backlog/ (26 stories), social_media/ (12 stories), and main stories (13 files)
- Files preserved in backlog/stories/impl/ folder structure
- Ready for planning agent to organize into proper backlog structure

## Next Steps
- Planning agent can review and reorganize stories
- Move high-priority stories to top-level backlog/
- Add proper frontmatter (status, priority, estimates)
- Remove stories/impl/ folder after reorganization